### PR TITLE
refactor(scaffolding): remove agent markup markers in favor of TODO p…

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,14 +12,14 @@ The project relies on strict TypeScript; keep new files inside `src` and leave c
 ## Testing Guidelines
 Place Jest specs alongside the files they cover with the `*.test.ts` suffix. Validate CLI behaviours against the compiled binary (`dist/index.js`) to mirror how end-users invoke the tool. Run `npm run build && npm run test` before sending a PR, and include `npm run test -- --coverage` when you touch critical flows or generators.
 
-## Documentation Markers & AI Tags
+## Documentation Conventions
 Scaffolded guides now include:
 - YAML front matter describing the AI task (`id`, `ai_update_goal`, `required_inputs`, `success_criteria`).
-- Update wrappers such as `<!-- agent-update:start:project-overview -->` ... `<!-- agent-update:end -->` that bound sections an agent may rewrite.
-- Placeholders like `<!-- agent-fill:directory-src -->` signalling content that still needs human-provided context.
-- Guard rails such as `<!-- agent-readonly:guidance -->` marking sections that should remain instructional unless a maintainer says otherwise.
+- Inline `TODO:` prompts to highlight areas that still need project-specific details.
+- Update Checklists that outline what to verify before considering a section complete.
+- Recommended Sources lists to keep future refreshes grounded in reliable references.
 
-When editing docs or adding new ones, preserve existing markers and introduce new ones where agents should focus future updates. Reference these markers from agent playbooks when you create specialised workflows.
+When editing docs or adding new ones, resolve the TODO prompts, keep the checklists accurate, and surface new resources that will help future contributors and agents stay aligned.
 
 ### LLM-assisted Updates
 - Use `ai-context fill <repo>` to apply the shared prompt (`prompts/update_scaffold_prompt.md`) across the scaffold.
@@ -34,4 +34,3 @@ No API keys are required for scaffolding; remove stale tokens from local `.env` 
 ## AI Context References
 - Documentation index: `.context/docs/README.md`
 - Agent playbooks: `.context/agents/README.md`
-

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A lightweight CLI that scaffolds living documentation and AI-agent playbooks for
 - 🤖 `agents/` folder containing playbooks for common engineering agents and a handy index
 - 🔁 Repeatable scaffolding that you can re-run as the project evolves
 - 🧭 Repository-aware templates that highlight top-level directories for quick orientation
-- 🧠 AI-ready front matter and `agent-update` markers so assistants know exactly what to refresh
+- 🧠 AI-ready front matter and clear update checklists so assistants know exactly what to refresh
 
 ## 📦 Installation
 
@@ -83,7 +83,7 @@ Customize the Markdown files to reflect your project’s specifics and commit th
 
 Need help filling in the scaffold? Use [`prompts/update_scaffold_prompt.md`](./prompts/update_scaffold_prompt.md) as the canonical instruction set for any LLM or CLI agent. It walks through:
 
-- Gathering repository context and locating `agent-update`/`agent-fill` markers.
+- Gathering repository context and reviewing TODO prompts inside the scaffold.
 - Updating documentation sections while satisfying the YAML front matter criteria.
 - Aligning agent playbooks with the refreshed docs and recording evidence for maintainers.
 
@@ -96,13 +96,13 @@ The scaffold includes the following guides and playbooks out of the box:
 - Docs: `project-overview`, `architecture`, `development-workflow`, `testing-strategy`, `glossary`, `data-flow`, `security`, `tooling`
 - Agents: `code-reviewer`, `bug-fixer`, `feature-developer`, `refactoring-specialist`, `test-writer`, `documentation-writer`, `performance-optimizer`, `security-auditor`, `backend-specialist`, `frontend-specialist`, `architect-specialist`
 
-### AI Marker Reference
+### Scaffold Conventions
 
-- `<!-- agent-update:start:section-id --> … <!-- agent-update:end -->` wrap the sections that AI assistants should rewrite with up-to-date project knowledge.
-- `<!-- agent-fill:slot-id --> … <!-- /agent-fill -->` highlight inline placeholders that must be replaced with concrete details before removing the wrapper.
-- `<!-- agent-readonly:context -->` flags guidance that should remain as-is; treat the adjacent content as instructions rather than editable prose.
+- Every guide starts with YAML front matter capturing the task goal, required inputs, and success criteria.
+- Inline `TODO:` prompts highlight spots that still need project-specific context.
+- Each document ends with an Update Checklist and Recommended Sources to keep future refreshes on track.
 
-When contributing, focus edits inside `agent-update` regions or `agent-fill` placeholders and leave `agent-readonly` guidance untouched unless you have explicit maintainer approval.
+When contributing, resolve the TODO prompts, keep the checklists current, and expand examples with project details as you learn more.
 
 ## 🛠 Commands
 

--- a/prompts/update_plan_prompt.md
+++ b/prompts/update_plan_prompt.md
@@ -6,8 +6,8 @@ You are an AI assistant responsible for refining collaboration plans that live i
 ## Preparation Checklist
 1. Review the plan’s YAML front matter to understand the stated `ai_update_goal`, `required_inputs`, and `success_criteria`.
 2. Inspect the provided documentation excerpts (from `docs/`) and agent playbooks to ensure the plan reflects their current guidance.
-3. Confirm that the “Agent Lineup” and “Documentation Touchpoints” tables link to real files and reference the correct `agent-update` markers.
-4. Note any TODOs, `agent-fill` placeholders, or missing evidence sections that must be resolved.
+3. Confirm that the “Agent Lineup” and “Documentation Touchpoints” tables link to real files and describe why each resource matters.
+4. Note any TODO prompts or missing evidence sections that must be resolved.
 
 ## Update Procedure
 1. **Task Snapshot**
@@ -20,7 +20,7 @@ You are an AI assistant responsible for refining collaboration plans that live i
 
 3. **Documentation Touchpoints**
    - Map each plan stage to the docs excerpts provided, highlighting which sections need to be updated during execution.
-   - Keep the table sorted and ensure the listed `agent-update` markers exist.
+   - Keep the table sorted and ensure each entry explains the guide’s focus or primary inputs.
 
 4. **Working Stages**
    - Break the work into clear stages with owners, deliverables, and evidence checkpoints.
@@ -31,7 +31,7 @@ You are an AI assistant responsible for refining collaboration plans that live i
    - Record any follow-up actions or decisions that require human confirmation.
 
 ## Acceptance Criteria
-- Every TODO or placeholder inside the plan’s `agent-update` block is resolved or accompanied by a clear escalation note.
+- Every TODO prompt inside the plan is resolved or accompanied by a clear escalation note.
 - Tables reference existing files and stay in sync with the docs/agent indices.
 - Stages provide actionable guidance, owners, and success signals.
 - The plan remains fully self-contained and ready for contributors to execute.

--- a/prompts/update_scaffold_prompt.md
+++ b/prompts/update_scaffold_prompt.md
@@ -7,18 +7,18 @@ You are an AI assistant responsible for refreshing the documentation (`docs/`) a
 1. Run `git status -sb` to understand pending changes.
 2. Review the latest merged commits or PRs related to documentation, architecture, workflow, or testing.
 3. Inspect `package.json`, CI configuration, and any release or roadmap notes stored in the repository.
-4. Check `docs/README.md` for the current document map and update AI markers (`agent-update:*`).
-5. Identify unresolved placeholders marked as `<!-- agent-fill:* -->`.
+4. Check `docs/README.md` for the current document map and confirm each guide listed still exists.
+5. Identify unresolved `TODO` prompts or sections flagged for human follow-up.
 
 ## Update Procedure
 1. **Select a Guide**
    - Navigate to `docs/<guide>.md`.
    - Read the YAML front matter (`ai_update_goal`, `required_inputs`, `success_criteria`) and ensure you collect the listed inputs before editing.
 
-2. **Edit Within Update Wrappers**
-   - Update content strictly inside the matching `<!-- agent-update:start:... -->` block and keep the closing `<!-- agent-update:end -->` tag.
-   - Remove or replace any `TODO` text with accurate, current information.
-   - When you complete a placeholder slot (`<!-- agent-fill:... -->`), remove the wrapper and provide the finalized description.
+2. **Edit the Guide**
+   - Keep the YAML front matter intact but update any fields that have changed.
+   - Replace every `TODO` prompt with accurate, current information.
+   - Refresh examples, tables, and summaries so they reflect the latest repository state.
 
 3. **Cross-Link Updates**
    - Verify that links between docs remain valid.
@@ -26,7 +26,7 @@ You are an AI assistant responsible for refreshing the documentation (`docs/`) a
 
 4. **Agent Playbook Alignment**
    - For each change in `docs/`, adjust the related `agents/*.md` playbooks.
-   - Ensure the "Documentation Touchpoints" list references the correct `agent-update` markers.
+   - Ensure the "Documentation Touchpoints" list references the relevant guides and accurately describes why they matter.
    - Update collaboration checklists and evidence sections to reflect the latest workflows.
 
 5. **Evidence & Traceability**
@@ -35,7 +35,7 @@ You are an AI assistant responsible for refreshing the documentation (`docs/`) a
 
 ## Acceptance Criteria
 - Every guide’s `success_criteria` field is satisfied.
-- No unresolved `TODO` or `agent-fill` blocks remain unless they require explicit human input; in such cases, add a comment explaining the dependency.
+- No unresolved `TODO` prompts remain unless they require explicit human input; in such cases, add a comment explaining the dependency.
 - Agent playbooks list accurate responsibilities, best practices, and pointer links to the refreshed docs.
 - Changes are self-contained, well-formatted Markdown, and reference any new external resources introduced.
 

--- a/src/generators/agents/agentGenerator.test.ts
+++ b/src/generators/agents/agentGenerator.test.ts
@@ -98,8 +98,8 @@ describe('AgentGenerator', () => {
     const playbookContent = await fs.readFile(path.join(agentsDir, 'code-reviewer.md'), 'utf8');
     expect(playbookContent).toContain('# Code Reviewer Agent Playbook');
     expect(playbookContent).toContain('Documentation Touchpoints');
-    expect(playbookContent).toContain('<!-- agent-update:start:agent-code-reviewer -->');
-    expect(playbookContent).toContain('agent-update:project-overview');
+    expect(playbookContent).toContain('Documentation index and navigation overview');
+    expect(playbookContent).toContain('Roadmap, README, stakeholder notes');
 
     const indexContent = await fs.readFile(path.join(agentsDir, 'README.md'), 'utf8');
     expect(indexContent).toContain('[Code Reviewer](./code-reviewer.md)');

--- a/src/generators/agents/agentGenerator.ts
+++ b/src/generators/agents/agentGenerator.ts
@@ -12,7 +12,7 @@ interface AgentContext {
 interface DocTouchpoint {
   title: string;
   path: string;
-  marker: string;
+  description: string;
 }
 
 export class AgentGenerator {
@@ -20,12 +20,12 @@ export class AgentGenerator {
     {
       title: 'Documentation Index',
       path: '../docs/README.md',
-      marker: 'agent-update:docs-index'
+      description: 'Documentation index and navigation overview'
     },
     ...DOCUMENT_GUIDES.map(guide => ({
       title: guide.title,
       path: `../docs/${guide.file}`,
-      marker: guide.marker
+      description: guide.primaryInputs
     }))
   ];
 

--- a/src/generators/agents/templates/playbookTemplate.ts
+++ b/src/generators/agents/templates/playbookTemplate.ts
@@ -12,14 +12,12 @@ export function renderAgentPlaybook(
   const responsibilities = AGENT_RESPONSIBILITIES[agentType] || ['Clarify this agent\'s responsibilities.'];
   const bestPractices = AGENT_BEST_PRACTICES[agentType] || ['Document preferred workflows.'];
   const directoryList = formatDirectoryList(topLevelDirectories);
-  const markerId = `agent-${agentType}`;
 
   const touchpointList = touchpoints
-    .map(tp => `- [${tp.title}](${tp.path}) — ${tp.marker}`)
-    .join('\n');
+    .map(tp => `- [${tp.title}](${tp.path}) — ${tp.description}`)
+    .join('\n') || '- Add documentation touchpoints relevant to this agent.';
 
-  return `<!-- agent-update:start:${markerId} -->
-# ${title} Agent Playbook
+  return `# ${title} Agent Playbook
 
 ## Mission
 Describe how the ${title.toLowerCase()} agent supports the team and when to engage it.
@@ -42,11 +40,10 @@ ${directoryList || '- Add directory highlights relevant to this agent.'}
 ## Documentation Touchpoints
 ${touchpointList}
 
-<!-- agent-readonly:guidance -->
 ## Collaboration Checklist
 1. Confirm assumptions with issue reporters or maintainers.
 2. Review open pull requests affecting this area.
-3. Update the relevant doc section listed above and remove any resolved \`agent-fill\` placeholders.
+3. Update the relevant doc section listed above and resolve any TODO placeholders.
 4. Capture learnings back in [docs/README.md](../docs/README.md) or the appropriate task marker.
 
 ## Success Metrics
@@ -87,7 +84,6 @@ Summarize outcomes, remaining risks, and suggested follow-up actions after the a
 - Command output or logs that informed recommendations.
 - Follow-up items for maintainers or future agent runs.
 - Performance metrics and benchmarks where applicable.
-<!-- agent-update:end -->
 `;
 }
 

--- a/src/generators/agents/templates/types.ts
+++ b/src/generators/agents/templates/types.ts
@@ -3,7 +3,7 @@ import { AgentType } from '../agentTypes';
 export interface DocTouchpoint {
   title: string;
   path: string;
-  marker: string;
+  description: string;
 }
 
 export interface AgentTemplateContext {

--- a/src/generators/documentation/documentationGenerator.test.ts
+++ b/src/generators/documentation/documentationGenerator.test.ts
@@ -75,7 +75,7 @@ describe('DocumentationGenerator', () => {
     }
   });
 
-  it('generates all guides with agent-update markers by default', async () => {
+  it('generates all guides with update checklists by default', async () => {
     const repoStructure = createRepoStructure(path.join(tempDir, 'repo'));
 
     const created = await generator.generateDocumentation(repoStructure, outputDir);
@@ -88,13 +88,13 @@ describe('DocumentationGenerator', () => {
     expect(files).toEqual(expectedFiles);
 
     const indexContent = await fs.readFile(path.join(docsDir, 'README.md'), 'utf8');
-    expect(indexContent).toContain('<!-- agent-update:start:docs-index -->');
     expect(indexContent).toContain('# Documentation Index');
+    expect(indexContent).toContain('## Update Checklist');
 
     const overviewContent = await fs.readFile(path.join(docsDir, 'project-overview.md'), 'utf8');
-    expect(overviewContent).toContain('<!-- agent-update:start:project-overview -->');
     expect(overviewContent).toContain('# Project Overview');
     expect(overviewContent).toContain('Root path:');
+    expect(overviewContent).toContain('## Update Checklist');
   });
 
   it('respects explicit guide selection', async () => {

--- a/src/generators/documentation/guideRegistry.ts
+++ b/src/generators/documentation/guideRegistry.ts
@@ -5,56 +5,48 @@ export const DOCUMENT_GUIDES: GuideMeta[] = [
     key: 'project-overview',
     title: 'Project Overview',
     file: 'project-overview.md',
-    marker: 'agent-update:project-overview',
     primaryInputs: 'Roadmap, README, stakeholder notes'
   },
   {
     key: 'architecture',
     title: 'Architecture Notes',
     file: 'architecture.md',
-    marker: 'agent-update:architecture-notes',
     primaryInputs: 'ADRs, service boundaries, dependency graphs'
   },
   {
     key: 'development-workflow',
     title: 'Development Workflow',
     file: 'development-workflow.md',
-    marker: 'agent-update:development-workflow',
     primaryInputs: 'Branching rules, CI config, contributing guide'
   },
   {
     key: 'testing-strategy',
     title: 'Testing Strategy',
     file: 'testing-strategy.md',
-    marker: 'agent-update:testing-strategy',
     primaryInputs: 'Test configs, CI gates, known flaky suites'
   },
   {
     key: 'glossary',
     title: 'Glossary & Domain Concepts',
     file: 'glossary.md',
-    marker: 'agent-update:glossary',
     primaryInputs: 'Business terminology, user personas, domain rules'
   },
   {
     key: 'data-flow',
     title: 'Data Flow & Integrations',
     file: 'data-flow.md',
-    marker: 'agent-update:data-flow',
     primaryInputs: 'System diagrams, integration specs, queue topics'
   },
   {
     key: 'security',
     title: 'Security & Compliance Notes',
     file: 'security.md',
-    marker: 'agent-update:security',
     primaryInputs: 'Auth model, secrets management, compliance requirements'
   },
   {
     key: 'tooling',
     title: 'Tooling & Productivity Guide',
     file: 'tooling.md',
-    marker: 'agent-update:tooling',
     primaryInputs: 'CLI scripts, IDE configs, automation workflows'
   }
 ];

--- a/src/generators/documentation/templates/apiReferenceTemplate.ts
+++ b/src/generators/documentation/templates/apiReferenceTemplate.ts
@@ -1,6 +1,5 @@
 export function renderApiReference(): string {
-  return `<!-- agent-update:start:api-reference -->
-# API Reference
+  return `# API Reference
 
 **Purpose:** Enable AI agents to programmatically interact with all API endpoints.
 
@@ -463,24 +462,21 @@ Document webhook registration process if applicable.
 - Link to Postman collection for easy testing
 - Link to OpenAPI/Swagger specification if available
 
-<!-- agent-readonly:guidance -->
-## AI Update Checklist
-1. Review route definitions and controller implementations for new or changed endpoints
-2. Verify authentication flows match current implementation
-3. Update rate limiting policies if thresholds changed
-4. Document new error codes and response formats
-5. Ensure all examples use realistic data and current API structure
-6. Validate that webhook event types are current
-7. Update SDK links and availability
+## Update Checklist
+1. Review route definitions and controller implementations for new or changed endpoints.
+2. Verify authentication flows match current implementation.
+3. Update rate limiting policies if thresholds changed.
+4. Document new error codes and response formats.
+5. Ensure all examples use realistic data and current API structure.
+6. Validate that webhook event types are current.
+7. Update SDK links and availability.
 
-<!-- agent-readonly:sources -->
-## Acceptable Sources
-- API route files and controller implementations
-- Authentication middleware and JWT/OAuth configurations
-- OpenAPI/Swagger specifications
-- Integration tests that demonstrate API usage
-- Postman collections or API testing suites
+## Recommended Sources
+- API route files and controller implementations.
+- Authentication middleware and JWT/OAuth configurations.
+- OpenAPI/Swagger specifications.
+- Integration tests that demonstrate API usage.
+- Postman collections or API testing suites.
 
-<!-- agent-update:end -->
 `;
 }

--- a/src/generators/documentation/templates/architectureTemplate.ts
+++ b/src/generators/documentation/templates/architectureTemplate.ts
@@ -5,8 +5,7 @@ export function renderArchitectureNotes(context: DocumentationTemplateContext): 
   const directorySnapshot = formatDirectoryStats(context.directoryStats);
   const coreComponentsSection = directorySnapshot || '- *Add notes for each core component or module.*';
 
-  return `<!-- agent-update:start:architecture-notes -->
-# Architecture Notes
+  return `# Architecture Notes
 
 > TODO: Describe how the system is assembled and why the current design exists.
 
@@ -42,16 +41,14 @@ ${coreComponentsSection}
 ## Top Directories Snapshot
 ${directorySnapshot}
 
-<!-- agent-readonly:guidance -->
-## AI Update Checklist
+## Update Checklist
 1. Review ADRs, design docs, or major PRs for architectural changes.
 2. Verify that each documented decision still holds; mark superseded choices clearly.
 3. Capture upstream/downstream impacts (APIs, events, data flows).
 4. Update Risks & Constraints with active incident learnings or TODO debt.
 5. Link any new diagrams or dashboards referenced in recent work.
 
-<!-- agent-readonly:sources -->
-## Acceptable Sources
+## Recommended Sources
 - ADR folders, \`/docs/architecture\` notes, or RFC threads.
 - Dependency visualisations from build tooling or scripts.
 - Issue tracker discussions vetted by maintainers.
@@ -59,7 +56,5 @@ ${directorySnapshot}
 ## Related Resources
 - [Project Overview](./project-overview.md)
 - Update [agents/README.md](../agents/README.md) when architecture changes.
-
-<!-- agent-update:end -->
 `;
 }

--- a/src/generators/documentation/templates/common.ts
+++ b/src/generators/documentation/templates/common.ts
@@ -28,15 +28,14 @@ export function formatDirectoryList(
         return `- \`${dir}/\``;
       }
 
-      const slotId = slugify(dir);
-      return `- <!-- agent-fill:directory-${slotId} -->\`${dir}/\` — TODO: Describe the purpose of this directory.<!-- /agent-fill -->`;
+      return `- \`${dir}/\` — TODO: Describe the purpose of this directory.`;
     })
     .join('\n');
 }
 
 export function buildDocumentMapTable(guides: DocumentationTemplateContext['guides']): string {
-  const rows = guides.map(meta => `| ${meta.title} | \`${meta.file}\` | ${meta.marker} | ${meta.primaryInputs} |`);
-  return ['| Guide | File | AI Marker | Primary Inputs |', '| --- | --- | --- | --- |', ...rows].join('\n');
+  const rows = guides.map(meta => `| ${meta.title} | \`${meta.file}\` | ${meta.primaryInputs} |`);
+  return ['| Guide | File | Primary Inputs |', '| --- | --- | --- |', ...rows].join('\n');
 }
 
 export function formatDirectoryStats(stats: DirectoryStat[]): string {
@@ -55,11 +54,4 @@ export function formatInlineDirectoryList(directories: string[]): string {
   }
 
   return directories.map(dir => `\`${dir}\``).join(', ');
-}
-
-export function slugify(value: string): string {
-  return value
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '');
 }

--- a/src/generators/documentation/templates/dataFlowTemplate.ts
+++ b/src/generators/documentation/templates/dataFlowTemplate.ts
@@ -2,8 +2,7 @@ import { DocumentationTemplateContext } from './types';
 import { formatInlineDirectoryList } from './common';
 
 export function renderDataFlow(context: DocumentationTemplateContext): string {
-  return `<!-- agent-update:start:data-flow -->
-# Data Flow & Integrations
+  return `# Data Flow & Integrations
 
 Explain how data enters, moves through, and exits the system, including interactions with external services.
 
@@ -14,25 +13,22 @@ Explain how data enters, moves through, and exits the system, including interact
 - Describe how modules within ${formatInlineDirectoryList(context.topLevelDirectories)} collaborate (queues, events, RPC calls, shared databases).
 
 ## External Integrations
-- <!-- agent-fill:integration -->**Integration** — Purpose, authentication, payload shapes, retry strategy.<!-- /agent-fill -->
+- **Integration** — Purpose, authentication, payload shapes, retry strategy.
 
 ## Observability & Failure Modes
 - Metrics, traces, or logs that monitor the flow.
 - Backoff, dead-letter, or compensating actions when downstream systems fail.
 
-<!-- agent-readonly:guidance -->
-## AI Update Checklist
+## Update Checklist
 1. Validate flows against the latest integration contracts or diagrams.
 2. Update authentication, scopes, or rate limits when they change.
 3. Capture recent incidents or lessons learned that influenced reliability.
 4. Link to runbooks or dashboards used during triage.
 
-<!-- agent-readonly:sources -->
-## Acceptable Sources
+## Recommended Sources
 - Architecture diagrams, ADRs, integration playbooks.
 - API specs, queue/topic definitions, infrastructure code.
 - Postmortems or incident reviews impacting data movement.
 
-<!-- agent-update:end -->
 `;
 }

--- a/src/generators/documentation/templates/developmentWorkflowTemplate.ts
+++ b/src/generators/documentation/templates/developmentWorkflowTemplate.ts
@@ -1,6 +1,5 @@
 export function renderDevelopmentWorkflow(): string {
-  return `<!-- agent-update:start:development-workflow -->
-# Development Workflow
+  return `# Development Workflow
 
 Outline the day-to-day engineering process for this repository.
 
@@ -21,20 +20,17 @@ Outline the day-to-day engineering process for this repository.
 - Point newcomers to first issues or starter tickets.
 - Link to internal runbooks or dashboards.
 
-<!-- agent-readonly:guidance -->
-## AI Update Checklist
+## Update Checklist
 1. Confirm branching/release steps with CI configuration and recent tags.
 2. Verify local commands against \`package.json\`; ensure flags and scripts still exist.
 3. Capture review requirements (approvers, checks) from contributing docs or repository settings.
 4. Refresh onboarding links (boards, dashboards) to their latest URLs.
 5. Highlight any manual steps that should become automation follow-ups.
 
-<!-- agent-readonly:sources -->
-## Acceptable Sources
+## Recommended Sources
 - CONTRIBUTING guidelines and \`AGENTS.md\`.
 - Build pipelines, branch protection rules, or release scripts.
 - Issue tracker boards used for onboarding or triage.
 
-<!-- agent-update:end -->
 `;
 }

--- a/src/generators/documentation/templates/glossaryTemplate.ts
+++ b/src/generators/documentation/templates/glossaryTemplate.ts
@@ -3,38 +3,34 @@ import { DocumentationTemplateContext } from './types';
 export function renderGlossary(_context: DocumentationTemplateContext): string {
 
   return `
-<!-- agent-update:start:glossary -->
 # Glossary & Domain Concepts
 
 List project-specific terminology, acronyms, domain entities, and user personas.
 
 ## Core Terms
-- <!-- agent-fill:term-one -->**Term** — Definition, relevance, and where it surfaces in the codebase.<!-- /agent-fill -->
-- <!-- agent-fill:term-two -->**Term** — Definition, domain context, related modules.<!-- /agent-fill -->
+- **Term** — Definition, relevance, and where it surfaces in the codebase.
+- **Term** — Definition, domain context, related modules.
 
 ## Acronyms & Abbreviations
-- <!-- agent-fill:acronym -->**ABC** — Expanded form; why we use it; associated services or APIs.<!-- /agent-fill -->
+- **ABC** — Expanded form; why we use it; associated services or APIs.
 
 ## Personas / Actors
-- <!-- agent-fill:persona -->**Persona Name** — Goals, key workflows, pain points addressed by the system.<!-- /agent-fill -->
+- **Persona Name** — Goals, key workflows, pain points addressed by the system.
 
 ## Domain Rules & Invariants
 - Capture business rules, validation constraints, or compliance requirements that the code enforces.
 - Note any region, localization, or regulatory nuances.
 
-<!-- agent-readonly:guidance -->
-## AI Update Checklist
+## Update Checklist
 1. Harvest terminology from recent PRs, issues, and discussions.
 2. Confirm definitions with product or domain experts when uncertain.
 3. Link terms to relevant docs or modules for deeper context.
 4. Remove or archive outdated concepts; flag unknown terms for follow-up.
 
-<!-- agent-readonly:sources -->
-## Acceptable Sources
+## Recommended Sources
 - Product requirement docs, RFCs, user research, or support tickets.
 - Service contracts, API schemas, data dictionaries.
 - Conversations with domain experts (summarize outcomes if applicable).
 
-<!-- agent-update:end -->
 `;
 }

--- a/src/generators/documentation/templates/indexTemplate.ts
+++ b/src/generators/documentation/templates/indexTemplate.ts
@@ -10,7 +10,6 @@ export function renderIndex(context: DocumentationTemplateContext): string {
     .join('\n') || '- *No guides selected.*';
 
   return `
-<!-- agent-update:start:docs-index -->
 # Documentation Index
 
 Welcome to the repository knowledge base. Start with the project overview, then dive into specific guides as needed.
@@ -24,19 +23,16 @@ ${directoryList || '*Top-level directories will appear here once the repository 
 ## Document Map
 ${documentMap}
 
-<!-- agent-readonly:guidance -->
-## AI Update Checklist
+## Update Checklist
 1. Gather context with \`git status -sb\` plus the latest commits touching \`docs/\` or \`agents/\`.
 2. Compare the current directory tree against the table above; add or retire rows accordingly.
 3. Update cross-links if guides moved or were renamed; keep anchor text concise.
 4. Record sources consulted inside the commit or PR description for traceability.
 
-<!-- agent-readonly:sources -->
-## Acceptable Sources
+## Recommended Sources
 - Repository tree and \`package.json\` scripts for canonical command names.
 - Maintainer-approved issues, RFCs, or product briefs referenced in the repo.
 - Release notes or changelog entries that announce documentation changes.
 
-<!-- agent-update:end -->
 `;
 }

--- a/src/generators/documentation/templates/migrationTemplate.ts
+++ b/src/generators/documentation/templates/migrationTemplate.ts
@@ -2,7 +2,6 @@
 export function renderMigration(): string {
 
   return `
-<!-- agent-update:start:migration-guide -->
 # Migration Guide
 
 Complete guide for upgrading between versions, handling breaking changes, and migrating data.
@@ -397,24 +396,21 @@ When reporting migration problems, include:
 4. Database type and version
 5. Steps to reproduce
 
-<!-- agent-readonly:guidance -->
-## AI Update Checklist
-1. Update version numbers and release dates when new versions are published
-2. Document new breaking changes with clear before/after examples
-3. Add migration paths for each new major version
-4. Update deprecation timeline as features are removed
-5. Include actual migration scripts and examples from the codebase
-6. Verify rollback procedures are tested and accurate
-7. Update system requirements for new versions
+## Update Checklist
+1. Update version numbers and release dates when new versions are published.
+2. Document new breaking changes with clear before/after examples.
+3. Add migration paths for each new major version.
+4. Update deprecation timeline as features are removed.
+5. Include actual migration scripts and examples from the codebase.
+6. Verify rollback procedures are tested and accurate.
+7. Update system requirements for new versions.
 
-<!-- agent-readonly:sources -->
-## Acceptable Sources
-- CHANGELOG.md and release notes
-- Migration scripts in migrations/ or db/migrate/ directory
-- Upgrade guides from official documentation
-- Post-mortem reports from previous migrations
-- Breaking changes documented in commit messages or PRs
+## Recommended Sources
+- CHANGELOG.md and release notes.
+- Migration scripts in migrations/ or db/migrate/ directories.
+- Upgrade guides from official documentation.
+- Post-mortem reports from previous migrations.
+- Breaking changes documented in commit messages or PRs.
 
-<!-- agent-update:end -->
 `;
 }

--- a/src/generators/documentation/templates/onboardingTemplate.ts
+++ b/src/generators/documentation/templates/onboardingTemplate.ts
@@ -2,7 +2,6 @@
 export function renderOnboarding(): string {
 
   return `
-<!-- agent-update:start:onboarding-guide -->
 # Onboarding Guide
 
 Welcome to the team! This guide will help you get set up and productive quickly.
@@ -406,24 +405,21 @@ We're always improving! Please provide feedback on:
 - Ask in #engineering if something is unclear
 - Your feedback helps future team members!
 
-<!-- agent-readonly:guidance -->
-## AI Update Checklist
-1. Verify all tool versions and installation instructions are current
-2. Update access request contacts with current team members
-3. Ensure all documentation links are valid
-4. Add new accounts or tools that team members need
-5. Update team communication channels and meeting schedules
-6. Refresh learning resources with current recommendations
-7. Verify suggested first issues are still appropriate
+## Update Checklist
+1. Verify all tool versions and installation instructions are current.
+2. Update access request contacts with current team members.
+3. Ensure all documentation links are valid.
+4. Add new accounts or tools that team members need.
+5. Update team communication channels and meeting schedules.
+6. Refresh learning resources with current recommendations.
+7. Verify suggested first issues are still appropriate.
 
-<!-- agent-readonly:sources -->
-## Acceptable Sources
-- Development environment setup scripts and documentation
-- Team wiki or handbook
-- IT/DevOps onboarding documentation
-- Feedback from recent new hires
-- Repository README and CONTRIBUTING files
+## Recommended Sources
+- Development environment setup scripts and documentation.
+- Team wiki or handbook.
+- IT/DevOps onboarding documentation.
+- Feedback from recent new hires.
+- Repository README and CONTRIBUTING files.
 
-<!-- agent-update:end -->
 `;
 }

--- a/src/generators/documentation/templates/projectOverviewTemplate.ts
+++ b/src/generators/documentation/templates/projectOverviewTemplate.ts
@@ -9,7 +9,6 @@ export function renderProjectOverview(context: DocumentationTemplateContext): st
     : '- Language mix pending analysis.';
 
   return `
-<!-- agent-update:start:project-overview -->
 # Project Overview
 
 > TODO: Summarize the problem this project solves and who benefits from it.
@@ -46,20 +45,17 @@ ${directoryList || '*Add a short description for each relevant directory.*'}
 ## Next Steps
 Capture product positioning, key stakeholders, and links to external documentation or product specs here.
 
-<!-- agent-readonly:guidance -->
-## AI Update Checklist
+## Update Checklist
 1. Review roadmap items or issues labelled “release” to confirm current goals.
 2. Cross-check Quick Facts against \`package.json\` and environment docs.
 3. Refresh the File Structure & Code Organization section to reflect new or retired modules; keep guidance actionable.
 4. Link critical dashboards, specs, or runbooks used by the team.
 5. Flag any details that require human confirmation (e.g., stakeholder ownership).
 
-<!-- agent-readonly:sources -->
-## Acceptable Sources
+## Recommended Sources
 - Recent commits, release notes, or ADRs describing high-level changes.
 - Product requirement documents linked from this repository.
 - Confirmed statements from maintainers or product leads.
 
-<!-- agent-update:end -->
 `;
 }

--- a/src/generators/documentation/templates/securityTemplate.ts
+++ b/src/generators/documentation/templates/securityTemplate.ts
@@ -2,7 +2,6 @@
 export function renderSecurity(): string {
 
   return `
-<!-- agent-update:start:security -->
 # Security & Compliance Notes
 
 Capture the policies and guardrails that keep this project secure and compliant.
@@ -19,19 +18,16 @@ Capture the policies and guardrails that keep this project secure and compliant.
 ## Incident Response
 - On-call contacts, escalation steps, and tooling for detection, triage, and post-incident analysis.
 
-<!-- agent-readonly:guidance -->
-## AI Update Checklist
+## Update Checklist
 1. Confirm security libraries and infrastructure match current deployments.
 2. Update secrets management details when storage or naming changes.
 3. Reflect new compliance obligations or audit findings.
 4. Ensure incident response procedures include current contacts and tooling.
 
-<!-- agent-readonly:sources -->
-## Acceptable Sources
+## Recommended Sources
 - Security architecture docs, runbooks, policy handbooks.
 - IAM/authorization configuration (code or infrastructure).
 - Compliance updates from security or legal teams.
 
-<!-- agent-update:end -->
 `;
 }

--- a/src/generators/documentation/templates/testingTemplate.ts
+++ b/src/generators/documentation/templates/testingTemplate.ts
@@ -2,7 +2,6 @@
 export function renderTestingStrategy(): string {
 
   return `
-<!-- agent-update:start:testing-strategy -->
 # Testing Strategy
 
 Document how quality is maintained across the codebase.
@@ -24,20 +23,17 @@ Document how quality is maintained across the codebase.
 ## Troubleshooting
 - Document flaky suites, long-running tests, or environment quirks.
 
-<!-- agent-readonly:guidance -->
-## AI Update Checklist
+## Update Checklist
 1. Review test scripts and CI workflows to confirm command accuracy.
 2. Update Quality Gates with current thresholds (coverage %, lint rules, required checks).
 3. Document new test categories or suites introduced since the last update.
 4. Record known flaky areas and link to open issues for visibility.
 5. Confirm troubleshooting steps remain valid with current tooling.
 
-<!-- agent-readonly:sources -->
-## Acceptable Sources
+## Recommended Sources
 - \`package.json\` scripts and testing configuration files.
 - CI job definitions (GitHub Actions, CircleCI, etc.).
 - Issue tracker items labelled “testing” or “flaky” with maintainer confirmation.
 
-<!-- agent-update:end -->
 `;
 }

--- a/src/generators/documentation/templates/toolingTemplate.ts
+++ b/src/generators/documentation/templates/toolingTemplate.ts
@@ -2,13 +2,12 @@
 export function renderToolingGuide(): string {
 
   return `
-<!-- agent-update:start:tooling -->
 # Tooling & Productivity Guide
 
 Collect the scripts, automation, and editor settings that keep contributors efficient.
 
 ## Required Tooling
-- <!-- agent-fill:tool-required -->Tool name — How to install, version requirements, what it powers.<!-- /agent-fill -->
+- Tool name — How to install, version requirements, what it powers.
 
 ## Recommended Automation
 - Pre-commit hooks, linting/formatting commands, code generators, or scaffolding scripts.
@@ -22,19 +21,16 @@ Collect the scripts, automation, and editor settings that keep contributors effi
 - Terminal aliases, container workflows, or local emulators mirroring production.
 - Links to shared scripts or dotfiles used across the team.
 
-<!-- agent-readonly:guidance -->
-## AI Update Checklist
+## Update Checklist
 1. Verify commands align with the latest scripts and build tooling.
 2. Remove instructions for deprecated tools and add replacements.
 3. Highlight automation that saves time during reviews or releases.
 4. Cross-link to runbooks or README sections that provide deeper context.
 
-<!-- agent-readonly:sources -->
-## Acceptable Sources
+## Recommended Sources
 - Onboarding docs, internal wikis, and team retrospectives.
 - Script directories, package manifests, CI configuration.
 - Maintainer recommendations gathered during pairing or code reviews.
 
-<!-- agent-update:end -->
 `;
 }

--- a/src/generators/documentation/templates/troubleshootingTemplate.ts
+++ b/src/generators/documentation/templates/troubleshootingTemplate.ts
@@ -2,7 +2,6 @@
 export function renderTroubleshooting(): string {
 
   return `
-<!-- agent-update:start:troubleshooting-guide -->
 # Troubleshooting Guide
 
 **Purpose:** Enable AI agents to diagnose and resolve issues using automated diagnostics and decision trees.
@@ -267,24 +266,21 @@ EOF
 echo "Escalation created. Agent awaiting human intervention."
 \`\`\`
 
-<!-- agent-readonly:guidance -->
-## AI Update Checklist
-1. Review recent incident reports and add new common issues
-2. Update diagnostic commands to match current tooling
-3. Verify contact information and escalation paths are current
-4. Add workarounds for newly discovered issues
-5. Update log locations and monitoring tool links
-6. Validate that debugging workflows match current setup
-7. Add new error patterns from support tickets
+## Update Checklist
+1. Review recent incident reports and add new common issues.
+2. Update diagnostic commands to match current tooling.
+3. Verify contact information and escalation paths are current.
+4. Add workarounds for newly discovered issues.
+5. Update log locations and monitoring tool links.
+6. Validate that debugging workflows match current setup.
+7. Add new error patterns from support tickets.
 
-<!-- agent-readonly:sources -->
-## Acceptable Sources
-- Post-mortem and incident reports
-- Support ticket patterns and resolutions
-- Production logs and error tracking systems
-- Team knowledge base and runbooks
-- Infrastructure and monitoring configurations
+## Recommended Sources
+- Post-mortem and incident reports.
+- Support ticket patterns and resolutions.
+- Production logs and error tracking systems.
+- Team knowledge base and runbooks.
+- Infrastructure and monitoring configurations.
 
-<!-- agent-update:end -->
 `;
 }

--- a/src/generators/documentation/templates/types.ts
+++ b/src/generators/documentation/templates/types.ts
@@ -4,7 +4,6 @@ export interface GuideMeta {
   key: string;
   title: string;
   file: string;
-  marker: string;
   primaryInputs: string;
 }
 

--- a/src/generators/plans/planGenerator.test.ts
+++ b/src/generators/plans/planGenerator.test.ts
@@ -38,10 +38,10 @@ describe('PlanGenerator', () => {
 
     const content = await fs.readFile(planPath, 'utf8');
     expect(content).toContain('id: plan-new-initiative');
-    expect(content).toContain('<!-- agent-update:start:plan-new-initiative -->');
     expect(content).toContain('# New Initiative Plan');
     expect(content).toContain('## Working Phases');
     expect(content).toContain('**Commit Checkpoint**');
+    expect(content).toContain('| Guide | File | Primary Inputs |');
 
     const indexContent = await fs.readFile(path.join(outputDir, 'plans', 'README.md'), 'utf8');
     expect(indexContent).toContain('1. [New Initiative](./new-initiative.md)');

--- a/src/generators/plans/templates/indexTemplate.ts
+++ b/src/generators/plans/templates/indexTemplate.ts
@@ -13,7 +13,7 @@ This directory is the run queue for AI agents and maintainers coordinating work 
 
 ## Agent Execution Protocol
 1. **Read the queue** from top to bottom. The numbering reflects execution priority.
-2. **Open the plan file** (e.g., './plans/<slug>.md') and review the YAML front matter and the '<!-- agent-update:start:plan-... -->' wrapper so you understand the goal, required inputs, and success criteria.
+2. **Open the plan file** (e.g., './plans/<slug>.md') and review the YAML front matter and opening sections so you understand the goal, required inputs, and success criteria.
 3. **Gather context** by visiting the linked documentation and agent playbooks referenced in the "Agent Lineup" and "Documentation Touchpoints" tables.
 4. **Execute the stages** exactly as written, capturing evidence and updating linked docs as instructed. If a stage cannot be completed, record the reason inside the plan before pausing.
 5. **Close out the plan** by updating any TODOs, recording outcomes in the "Evidence & Follow-up" section, and notifying maintainers if human review is required.

--- a/src/generators/plans/templates/planTemplate.ts
+++ b/src/generators/plans/templates/planTemplate.ts
@@ -15,9 +15,9 @@ export function renderPlanTemplate(context: PlanTemplateContext): string {
 
   const docsTableRows = docs.length
     ? docs
-        .map(doc => `| ${doc.title} | [${doc.file}](../docs/${doc.file}) | ${doc.marker} | ${doc.primaryInputs} |`)
+        .map(doc => `| ${doc.title} | [${doc.file}](../docs/${doc.file}) | ${doc.primaryInputs} |`)
         .join('\n')
-    : '| Documentation Index | [README.md](../docs/README.md) | agent-update:docs-index | Current docs directory listing |';
+    : '| Documentation Index | [README.md](../docs/README.md) | Key navigation and repository context |';
 
   return `---
 id: plan-${slug}
@@ -34,7 +34,6 @@ related_agents:
 ${relatedAgents}
 ---
 
-<!-- agent-update:start:plan-${slug} -->
 # ${title} Plan
 
 > ${summary?.trim() || 'TODO: Summarize the desired outcome and the problem this plan addresses.'}
@@ -53,8 +52,8 @@ ${relatedAgents}
 ${agentTableRows}
 
 ## Documentation Touchpoints
-| Guide | File | Task Marker | Primary Inputs |
-| --- | --- | --- | --- |
+| Guide | File | Primary Inputs |
+| --- | --- | --- |
 ${docsTableRows}
 
 ## Risk Assessment
@@ -152,7 +151,6 @@ When to initiate rollback:
 3. Schedule post-mortem to analyze failure
 4. Update plan with lessons learned before retry
 
-<!-- agent-readonly:guidance -->
 ## Agent Playbook Checklist
 1. Pick the agent that matches your task.
 2. Enrich the template with project-specific context or links.
@@ -162,7 +160,5 @@ When to initiate rollback:
 ## Evidence & Follow-up
 - TODO: List artifacts to collect (logs, PR links, test runs, design notes).
 - TODO: Record follow-up actions or owners.
-
-<!-- agent-update:end -->
 `;
 }

--- a/src/prompts/defaults.ts
+++ b/src/prompts/defaults.ts
@@ -7,18 +7,18 @@ You are an AI assistant responsible for refreshing the documentation (\`docs/\`)
 1. Run \`git status -sb\` to understand pending changes.
 2. Review the latest merged commits or PRs related to documentation, architecture, workflow, or testing.
 3. Inspect \`package.json\`, CI configuration, and any release or roadmap notes stored in the repository.
-4. Check \`docs/README.md\` for the current document map and update AI markers (\`agent-update:*\`).
-5. Identify unresolved placeholders marked as \`<!-- agent-fill:* -->\`.
+4. Check \`docs/README.md\` for the current document map and confirm each guide listed still exists.
+5. Identify unresolved \`TODO\` prompts or sections flagged for human follow-up.
 
 ## Update Procedure
 1. **Select a Guide**
    - Navigate to \`docs/<guide>.md\`.
    - Read the YAML front matter (\`ai_update_goal\`, \`required_inputs\`, \`success_criteria\`) and ensure you collect the listed inputs before editing.
 
-2. **Edit Within Update Wrappers**
-   - Update content strictly inside the matching \`<!-- agent-update:start:... -->\` block and keep the closing \`<!-- agent-update:end -->\` tag.
-   - Remove or replace any \`TODO\` text with accurate, current information.
-   - When you complete a placeholder slot (\`<!-- agent-fill:... -->\`), remove the wrapper and provide the finalized description.
+2. **Edit the Guide**
+   - Keep the YAML front matter intact but update any fields that have changed.
+   - Replace every \`TODO\` prompt with accurate, current information.
+   - Refresh examples, tables, and summaries so they reflect the latest repository state.
 
 3. **Cross-Link Updates**
    - Verify that links between docs remain valid.
@@ -26,7 +26,7 @@ You are an AI assistant responsible for refreshing the documentation (\`docs/\`)
 
 4. **Agent Playbook Alignment**
    - For each change in \`docs/\`, adjust the related \`agents/*.md\` playbooks.
-   - Ensure the "Documentation Touchpoints" list references the correct \`agent-update\` markers.
+   - Ensure the "Documentation Touchpoints" list references the relevant guides and accurately describes why they matter.
    - Update collaboration checklists and evidence sections to reflect the latest workflows.
 
 5. **Evidence & Traceability**
@@ -35,7 +35,7 @@ You are an AI assistant responsible for refreshing the documentation (\`docs/\`)
 
 ## Acceptance Criteria
 - Every guide’s \`success_criteria\` field is satisfied.
-- No unresolved \`TODO\` or \`agent-fill\` blocks remain unless they require explicit human input; in such cases, add a comment explaining the dependency.
+- No unresolved \`TODO\` prompts remain unless they require explicit human input; in such cases, add a comment explaining the dependency.
 - Agent playbooks list accurate responsibilities, best practices, and pointer links to the refreshed docs.
 - Changes are self-contained, well-formatted Markdown, and reference any new external resources introduced.
 
@@ -55,8 +55,8 @@ You are an AI assistant responsible for refining collaboration plans that live i
 ## Preparation Checklist
 1. Review the plan’s YAML front matter to understand the stated \`ai_update_goal\`, \`required_inputs\`, and \`success_criteria\`.
 2. Inspect the provided documentation excerpts (from \`docs/\`) and agent playbooks to ensure the plan reflects their current guidance.
-3. Confirm that the “Agent Lineup” and “Documentation Touchpoints” tables link to real files and reference the correct \`agent-update\` markers.
-4. Note any TODOs, \`agent-fill\` placeholders, or missing evidence sections that must be resolved.
+3. Confirm that the “Agent Lineup” and “Documentation Touchpoints” tables link to real files and describe why each resource matters.
+4. Note any TODO prompts or missing evidence sections that must be resolved.
 
 ## Update Procedure
 1. **Task Snapshot**
@@ -69,7 +69,7 @@ You are an AI assistant responsible for refining collaboration plans that live i
 
 3. **Documentation Touchpoints**
    - Map each plan stage to the docs excerpts provided, highlighting which sections need to be updated during execution.
-   - Keep the table sorted and ensure the listed \`agent-update\` markers exist.
+   - Keep the table sorted and ensure each entry explains the guide’s focus or primary inputs.
 
 4. **Working Phases**
    - Break the work into sequential phases that each include a numbered list of steps, accountable owners, deliverables, and evidence expectations.
@@ -81,7 +81,7 @@ You are an AI assistant responsible for refining collaboration plans that live i
    - Record any follow-up actions or decisions that require human confirmation.
 
 ## Acceptance Criteria
-- Every TODO or placeholder inside the plan’s \`agent-update\` block is resolved or accompanied by a clear escalation note.
+- Every TODO prompt inside the plan is resolved or accompanied by a clear escalation note.
 - Tables reference existing files and stay in sync with the docs/agent indices.
 - Phases provide actionable guidance, include numbered steps, and end with an explicit Git commit checkpoint.
 - The plan remains fully self-contained and ready for contributors to execute.

--- a/src/runInit.integration.test.ts
+++ b/src/runInit.integration.test.ts
@@ -44,8 +44,8 @@ describe('runInit integration', () => {
     expect(await fs.pathExists(agentsDir)).toBe(true);
 
     const docsIndex = await fs.readFile(path.join(docsDir, 'README.md'), 'utf8');
-    expect(docsIndex).toContain('<!-- agent-update:start:docs-index -->');
     expect(docsIndex).toContain('Repository Snapshot');
+    expect(docsIndex).toContain('Update Checklist');
 
     const agentIndex = await fs.readFile(path.join(agentsDir, 'README.md'), 'utf8');
     expect(agentIndex).toContain('# Agent Handbook');

--- a/src/services/fill/fillService.ts
+++ b/src/services/fill/fillService.ts
@@ -265,8 +265,8 @@ export class FillService {
 
   private buildUserPrompt(relativePath: string, currentContent: string, contextSummary: string, isAgent: boolean): string {
     const guidance: string[] = [
-      '- Preserve YAML front matter and existing `agent-update` sections.',
-      '- Replace TODOs and resolve `agent-fill` placeholders with concrete information.',
+      '- Preserve YAML front matter and existing structural headings.',
+      '- Replace every TODO prompt with concrete information.',
       '- Ensure success criteria in the front matter are satisfied.',
       '- Return only the full updated Markdown for this file.'
     ];

--- a/src/services/plan/planService.ts
+++ b/src/services/plan/planService.ts
@@ -274,7 +274,7 @@ export class PlanService {
 
   private buildPlanUserPrompt(context: PlanPromptContext): string {
     const guidance = [
-      '- Preserve the YAML front matter and `agent-update` wrapper already in the plan.',
+      '- Preserve the YAML front matter and overall plan structure (headings, tables, phase layout).',
       '- Replace TODOs with concrete steps that align with the provided documentation and agent playbooks.',
       '- Keep the Agent Lineup and Documentation Touchpoints tables accurate and sorted.',
       '- Ensure the work is segmented into phases, each with numbered steps, named owners, deliverables, evidence expectations, and a concluding Git commit checkpoint.',


### PR DESCRIPTION
…rompts

Replace complex agent-update and agent-fill markup system with simpler TODO prompts and update checklists across all documentation templates and generators. This change streamlines the scaffolding system by removing wrapper markers and replacing them with inline TODO comments that are easier to maintain and understand. The update affects all documentation templates, agent playbooks, test expectations, and prompt instructions.