### PR TITLE
chore: release version 0.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.2] - 2026-01-09
+
+### Fixed
+
+- **Dotenv configuration handling**: Updated dotenv configuration to respect command-line arguments
+  - MCP server now skips loading `.env` file when `--skip-dotenv` flag is passed
+  - Prevents environment variable conflicts when running as MCP server
+  - Fix MCP to work in Antigravity and Codex
+
 ## [0.5.1] - 2026-01-09
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -146,6 +146,16 @@ Configure in Cline settings (VS Code → Settings → Cline → MCP Servers):
 }
 ```
 
+### Codex CLI
+
+Add to your Codex CLI config (`~/.codex/config.toml`):
+
+```toml
+[mcp_servers.ai-context]
+command = "npx"
+args = ["--yes", "@ai-coders/context@latest", "mcp"]
+```
+
 ### Available MCP Tools
 
 Once configured, your AI assistant will have access to:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ai-coders/context",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "CLI tool for generating codebase documentation and AI agent prompts",
   "main": "dist/index.js",
   "bin": {


### PR DESCRIPTION
- Updated dotenv configuration to respect command-line arguments, allowing the MCP server to skip loading the `.env` file when the `--skip-dotenv` flag is used.
- Added configuration instructions for Codex CLI to the README for easier setup.