### PR TITLE
Enhance MCP server setup documentation for Antigravity

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,44 @@ The system automatically detects project scale and adjusts the workflow:
 
 This package includes an MCP (Model Context Protocol) server that provides AI coding assistants with powerful tools to analyze and document your codebase.
 
+### Antigravity
+
+#### 1. Access Raw Config
+
+The visual interface only shows official partners, but the manual editing mode allows any local or remote executable.
+
+1. Open the **Agent** panel (usually in the sidebar or `Ctrl+L`).
+2. Click the options menu (three dots `...`) or the settings icon.
+3. Select **Manage MCP Servers**.
+4. At the top of this screen, look for a discreet button or link named **"View raw config"** or **"Edit JSON"**.
+
+> **Note:** If you cannot find the button in the UI, you can navigate directly through the file explorer and look for `.idx/mcp.json` or `mcp_config.json` in your workspace root.
+
+#### 2. Add Custom Server
+
+You will see a JSON file. You must add a new entry inside the `"mcpServers"` object.
+
+Here is the template to add a server (example using `npx` for a Node.js server or a local executable):
+
+```json
+{
+  "mcpServers": {
+    "ai-context": {
+      "command": "npx",
+      "args": ["@ai-coders/context", "mcp"]
+    }
+  }
+}
+```
+
+#### 3. Restart the Connection
+
+After saving the `mcp.json` file:
+
+1. Return to the **"Manage MCP Servers"** panel.
+2. Click the **Refresh** button or restart the Antigravity environment (*Reload Window*).
+3. The new server should appear in the list with a status indicator (usually a green light if connected successfully).
+
 ### Claude Code (CLI)
 
 Add the MCP server using the Claude CLI:


### PR DESCRIPTION
Added instructions for accessing raw config, adding custom servers, and restarting the connection in the MCP server setup in Antigravity.