### PR TITLE
fix: exclude venv from semantic analysis

### DIFF
--- a/src/services/ai/tools/initializeContextTool.ts
+++ b/src/services/ai/tools/initializeContextTool.ts
@@ -59,6 +59,17 @@ The AI agent MUST then fill each generated file using the provided context and i
       // Ensure output directory exists
       await fs.ensureDir(outputDir);
 
+      // Persist user-provided exclude patterns for later use by fillSingle
+      if (exclude.length > 0) {
+        const configPath = path.join(outputDir, 'config.json');
+        let existingConfig: Record<string, unknown> = {};
+        if (await fs.pathExists(configPath)) {
+          try { existingConfig = await fs.readJson(configPath); } catch { /* ignore */ }
+        }
+        existingConfig.exclude = exclude;
+        await fs.writeJson(configPath, existingConfig, { spaces: 2 });
+      }
+
       // Map repository structure
       const fileMapper = new FileMapper(exclude);
       const repoStructure = await fileMapper.mapRepository(resolvedRepoPath, include);

--- a/src/services/semantic/contextBuilder.ts
+++ b/src/services/semantic/contextBuilder.ts
@@ -14,6 +14,7 @@ import type {
   DetectedPattern,
   AnalyzerOptions,
 } from './types';
+import { DEFAULT_EXCLUDE_PATTERNS } from './types';
 
 export interface ContextBuilderOptions extends AnalyzerOptions {
   /** Maximum symbols to include per category */
@@ -31,7 +32,7 @@ export type ContextFormat = 'documentation' | 'playbook' | 'plan' | 'compact';
 const DEFAULT_OPTIONS: Required<ContextBuilderOptions> = {
   useLSP: false,
   languages: ['typescript', 'javascript', 'python', 'go'],
-  exclude: ['node_modules', 'dist', 'build', '.git', 'coverage'],
+  exclude: DEFAULT_EXCLUDE_PATTERNS,
   include: [],
   maxFiles: 5000,
   cacheEnabled: true,

--- a/src/services/semantic/types.ts
+++ b/src/services/semantic/types.ts
@@ -228,4 +228,6 @@ export const DEFAULT_EXCLUDE_PATTERNS = [
   'coverage',
   '.cache',
   'target',
+  'venv',
+  '.venv',
 ];


### PR DESCRIPTION
## Summary

- Adds `venv/` and `.venv/` to `DEFAULT_EXCLUDE_PATTERNS` so Python virtual environments are excluded from semantic analysis by default
- Updates `SemanticContextBuilder` to use the shared `DEFAULT_EXCLUDE_PATTERNS` instead of its own shorter hardcoded list
- Persists user-provided exclude patterns from `init` to `.context/config.json`, so `fillSingle` respects them instead of falling back to hardcoded defaults

## Problem

When running `fillSingle` on a Python project with a `venv/` directory, the semantic context was polluted with hundreds of `site-packages` paths, making the generated documentation unusable. Three related issues:

1. `DEFAULT_EXCLUDE_PATTERNS` was missing `venv`/`.venv`
2. `SemanticContextBuilder` maintained its own exclude list rather than using the shared defaults
3. User exclude patterns passed to `init` were never persisted — `fillSingle` always fell back to hardcoded defaults

## Test plan

- [x] Run `init` with `exclude: ["venv", ".venv"]` on a Python project with a virtual environment
- [x] Run `fillSingle` on a doc file and verify zero `venv/` or `site-packages` paths in semantic context

🤖 Generated with [Claude Code](https://claude.com/claude-code)