### PR TITLE
fill: process skills before agents

### DIFF
--- a/src/services/fill/fillService.ts
+++ b/src/services/fill/fillService.ts
@@ -53,6 +53,7 @@ interface ResolvedFillOptions {
   repoPath: string;
   outputDir: string;
   docsDir: string;
+  skillsDir: string;
   agentsDir: string;
   include?: string[];
   exclude?: string[];
@@ -110,13 +111,15 @@ export class FillService {
     const resolvedRepo = path.resolve(repoPath);
     const outputDir = path.resolve(rawOptions.output || './.context');
     const docsDir = path.join(outputDir, 'docs');
+    const skillsDir = path.join(outputDir, 'skills');
     const agentsDir = path.join(outputDir, 'agents');
 
-    // At least one of docs or agents must exist
+    // At least one fillable scaffold directory must exist
     const docsExists = await fs.pathExists(docsDir);
+    const skillsExists = await fs.pathExists(skillsDir);
     const agentsExists = await fs.pathExists(agentsDir);
 
-    if (!docsExists && !agentsExists) {
+    if (!docsExists && !skillsExists && !agentsExists) {
       throw new Error(this.t('errors.fill.missingScaffold'));
     }
 
@@ -144,6 +147,7 @@ export class FillService {
       repoPath: resolvedRepo,
       outputDir,
       docsDir,
+      skillsDir,
       agentsDir,
       include: rawOptions.include,
       exclude: rawOptions.exclude,
@@ -350,10 +354,13 @@ export class FillService {
     const docFiles = (await fs.pathExists(options.docsDir))
       ? await glob('**/*.md', { cwd: options.docsDir, absolute: true })
       : [];
+    const skillFiles = (await fs.pathExists(options.skillsDir))
+      ? await glob('**/*.md', { cwd: options.skillsDir, absolute: true })
+      : [];
     const agentFiles = (await fs.pathExists(options.agentsDir))
       ? await glob('**/*.md', { cwd: options.agentsDir, absolute: true })
       : [];
-    const candidates = [...docFiles, ...agentFiles];
+    const candidates = [...docFiles, ...skillFiles, ...agentFiles];
 
     const targets: TargetFile[] = [];
 

--- a/src/services/mcp/gateway/types.ts
+++ b/src/services/mcp/gateway/types.ts
@@ -46,7 +46,7 @@ export interface ContextParams {
   exclude?: string[];
   autoFill?: boolean;
   skipContentGeneration?: boolean;
-  target?: 'docs' | 'agents' | 'plans' | 'all';
+  target?: 'docs' | 'skills' | 'agents' | 'plans' | 'all';
   offset?: number;
   limit?: number;
   filePath?: string;

--- a/src/services/mcp/mcpServer.ts
+++ b/src/services/mcp/mcpServer.ts
@@ -180,7 +180,7 @@ export class AIContextMCPServer {
           .describe('(init, scaffoldPlan) Auto-fill with codebase content'),
         skipContentGeneration: z.boolean().optional()
           .describe('(init) Skip pre-generating content'),
-        target: z.enum(['docs', 'agents', 'plans', 'all']).optional()
+        target: z.enum(['docs', 'skills', 'agents', 'plans', 'all']).optional()
           .describe('(fill, listToFill) Which scaffolding to target'),
         offset: z.number().optional()
           .describe('(fill) Skip first N files'),


### PR DESCRIPTION
 ## Summary
                                                                                                                                          
  This PR updates the fill workflow to process skills before agents, so agent content can reference already-filled skills.                
                                                                                                                                          
  ## What Changed                                                                                                                         
                                                                                                                                          
  - Updated fill target ordering to docs -> skills -> agents.                                                                             
  - Added skills support to context fill/list target enums in MCP and gateway types.                                                      
  - Extended scaffolding fill tools to include skills in listings and pagination.                                                         
  - Added recursive skills discovery in fill tooling to support nested skill layout (.context/skills/<slug>/SKILL.md).                    
  - Updated fill service validation to accept runs when only skills exist.                                                                
  - Added/updated tests to verify:                                                                                                        
      - fills work with only skills,                                                                                                      
      - skills are processed before agents.                                                                                               
                                                                                                                                          
  ## Files Changed                                                                                                                        
                                                                                                                                          
  - src/services/fill/fillService.ts                                                                                                      
  - src/services/fill/fillService.test.ts                                                                                                 
  - src/services/ai/tools/fillScaffoldingTool.ts                                                                                          
  - src/services/mcp/mcpServer.ts                                                                                                         
  - src/services/mcp/gateway/types.ts                                                                                                     
                                                                                                                                          
  ## Why                                                                                                                                  
                                                                                                                                          
  Agents should be generated with access to completed skill content. Previously, agents could be filled before skills were available in   
  the flow.                                                                                                                               
                                                                                                                                          
  ## Validation                                                                                                                           
                                                                                                                                          
  - npm run build ✅                                                                                                                      
  - npm test -- src/services/fill/fillService.test.ts -- --runInBand ✅ (20 tests passing)                                                
                                                                                                                                          
  ## Notes                                                                                                                                
                                                                                                                                          
  - This change preserves existing docs-first behavior while ensuring skills are available prior to agent fill.                           
  - No breaking CLI command changes; this is ordering and target coverage improvement.  