### PR TITLE
fix: preserve frontmatter in fill and
  filter already-filled files

### DIFF
--- a/src/services/ai/tools/fillScaffoldingTool.ts
+++ b/src/services/ai/tools/fillScaffoldingTool.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 import * as fs from 'fs-extra';
 import { z } from 'zod';
 import { SemanticContextBuilder } from '../../semantic/contextBuilder';
+import { needsFill } from '../../../utils/frontMatter';
 
 // Shared context builder instance for efficiency
 let sharedContextBuilder: SemanticContextBuilder | null = null;
@@ -86,11 +87,9 @@ Use this first to get the list, then call fillSingleFile for each file.`,
           const docFiles = await fs.readdir(docsDir);
           for (const file of docFiles) {
             if (!file.endsWith('.md')) continue;
-            files.push({
-              path: path.join(docsDir, file),
-              relativePath: `docs/${file}`,
-              type: 'doc'
-            });
+            const filePath = path.join(docsDir, file);
+            if (!await needsFill(filePath)) continue;
+            files.push({ path: filePath, relativePath: `docs/${file}`, type: 'doc' });
           }
         }
       }
@@ -102,11 +101,9 @@ Use this first to get the list, then call fillSingleFile for each file.`,
           const agentFiles = await fs.readdir(agentsDir);
           for (const file of agentFiles) {
             if (!file.endsWith('.md') || file.toLowerCase() === 'readme.md') continue;
-            files.push({
-              path: path.join(agentsDir, file),
-              relativePath: `agents/${file}`,
-              type: 'agent'
-            });
+            const filePath = path.join(agentsDir, file);
+            if (!await needsFill(filePath)) continue;
+            files.push({ path: filePath, relativePath: `agents/${file}`, type: 'agent' });
           }
         }
       }
@@ -118,11 +115,9 @@ Use this first to get the list, then call fillSingleFile for each file.`,
           const planFiles = await fs.readdir(plansDir);
           for (const file of planFiles) {
             if (!file.endsWith('.md') || file.toLowerCase() === 'readme.md') continue;
-            files.push({
-              path: path.join(plansDir, file),
-              relativePath: `plans/${file}`,
-              type: 'plan'
-            });
+            const filePath = path.join(plansDir, file);
+            if (!await needsFill(filePath)) continue;
+            files.push({ path: filePath, relativePath: `plans/${file}`, type: 'plan' });
           }
         }
       }
@@ -285,11 +280,9 @@ After calling this tool, write the suggestedContent to each file path.`,
           const docFiles = await fs.readdir(docsDir);
           for (const file of docFiles) {
             if (!file.endsWith('.md')) continue;
-            allFiles.push({
-              path: path.join(docsDir, file),
-              relativePath: path.relative(outputDir, path.join(docsDir, file)),
-              type: 'doc'
-            });
+            const filePath = path.join(docsDir, file);
+            if (!await needsFill(filePath)) continue;
+            allFiles.push({ path: filePath, relativePath: path.relative(outputDir, filePath), type: 'doc' });
           }
         }
       }
@@ -301,11 +294,9 @@ After calling this tool, write the suggestedContent to each file path.`,
           const agentFiles = await fs.readdir(agentsDir);
           for (const file of agentFiles) {
             if (!file.endsWith('.md') || file.toLowerCase() === 'readme.md') continue;
-            allFiles.push({
-              path: path.join(agentsDir, file),
-              relativePath: path.relative(outputDir, path.join(agentsDir, file)),
-              type: 'agent'
-            });
+            const filePath = path.join(agentsDir, file);
+            if (!await needsFill(filePath)) continue;
+            allFiles.push({ path: filePath, relativePath: path.relative(outputDir, filePath), type: 'agent' });
           }
         }
       }
@@ -317,11 +308,9 @@ After calling this tool, write the suggestedContent to each file path.`,
           const planFiles = await fs.readdir(plansDir);
           for (const file of planFiles) {
             if (!file.endsWith('.md') || file.toLowerCase() === 'readme.md') continue;
-            allFiles.push({
-              path: path.join(plansDir, file),
-              relativePath: path.relative(outputDir, path.join(plansDir, file)),
-              type: 'plan'
-            });
+            const filePath = path.join(plansDir, file);
+            if (!await needsFill(filePath)) continue;
+            allFiles.push({ path: filePath, relativePath: path.relative(outputDir, filePath), type: 'plan' });
           }
         }
       }

--- a/src/utils/frontMatter.ts
+++ b/src/utils/frontMatter.ts
@@ -22,7 +22,7 @@ const FRONT_MATTER_DELIMITER = '---';
  */
 export async function needsFill(filePath: string): Promise<boolean> {
   try {
-    const firstLines = await readFirstLines(filePath, 3);
+    const firstLines = await readFirstLines(filePath, 15);
     return firstLines.some(line => line.includes('status: unfilled'));
   } catch {
     return false;


### PR DESCRIPTION
## Problem

  Three related bugs that create a destructive infinite loop when using the `fill` CLI and MCP tools.

  Fixes #29

  ## Root causes

  ### 1. `needsFill()` never detects filled files
  `frontMatter.ts` read only the first 3 lines to detect `status: unfilled`, but the `status` field sits on line 6–8 of the frontmatter block. It was always returning
  `false`, meaning every file looked unfilled forever.

  ### 2. `listFilesToFillTool` and `fillScaffoldingTool` list everything unconditionally
  Both MCP tools collected all `.md` files without calling `needsFill()`. Even after filling, they kept reporting 100% of files as pending, triggering repeated fill runs.

  ### 3. `fillService` discards original frontmatter on write
  `processTarget()` and `processTargetWithAgent()` called `removeFrontMatter()` on the LLM output (correct), but then wrote the file without restoring the original
  frontmatter. Every fill silently destroyed the metadata. `collectTargets()` also had no `needsFill()` guard.

  ## Changes

  **`src/utils/frontMatter.ts`**
  - `needsFill()`: read 15 lines instead of 3 — captures `status:` regardless of frontmatter size

  **`src/services/fill/fillService.ts`**
  - `processTarget()` and `processTargetWithAgent()`: extract original frontmatter before LLM call, strip LLM output frontmatter, reconstruct file with original metadata and
  `status: filled`
  - `collectTargets()`: skip files where `needsFill()` returns false

  **`src/services/ai/tools/fillScaffoldingTool.ts`**
  - `listFilesToFillTool`: filter each file through `needsFill()` before adding to results
  - `fillScaffoldingTool`: same filter applied to paginated collection

  ## Testing

  21 unit tests passing. Pre-existing build failures related to `tree-sitter` type declarations are unrelated to this change.