### PR TITLE
feat: add Claude Code bootstrap (mcp + hooks + agents)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ output/
 
 # AI Context state files
 context-log.json
+.claude/settings.local.json
 
 # Temporary files
 *.tmp

--- a/Orquestração Design Systems.md
+++ b/Orquestração Design Systems.md
@@ -1,0 +1,422 @@
+# Orquestracao Design Systems
+
+## Objetivo
+Criar um fluxo padrao em que o **Cloud Client** chama o **MCP Server**, o MCP gera um **Design System completo com preview HTML**, coleta aprovacao do usuario e, somente apos aprovacao, gera um artefato final `.md` para aplicacao automatica na landing page.
+
+## Meta de Execucao Confiavel
+- Sem ambiguidade de entrada e saida.
+- Pipeline deterministico com gates obrigatorios.
+- Sem aplicacao automatica sem aprovacao explicita.
+- Falha segura: se validacao falhar, retorna `needs_revision` e bloqueia o artefato final `.md`.
+
+---
+
+## 1) Arquitetura (alto nivel)
+
+### Componentes
+1. `Cloud Client`
+- Coleta PRD/plano e preferencias visuais.
+- Inicia requisicao ao MCP.
+- Mostra preview para aprovacao.
+- Dispara aplicacao quando o artefato `.md` estiver aprovado.
+
+2. `MCP Server`
+- Recebe requisicao e orquestra o pipeline.
+- Gera tokens, componentes e preview.
+- Executa validacoes tecnicas.
+- Controla estados (`draft`, `ready_for_review`, `approved`, `needs_revision`).
+
+3. `DS Engine` (dentro do MCP)
+- Gera foundations (cores, tipografia, spacing, radius, elevation, breakpoints).
+- Gera componentes (Button, Input, Card, Navbar, Footer).
+- Gera templates de secao (Hero, Features, Testimonials, FAQ, CTA).
+
+4. `Preview Service` (dentro do MCP)
+- Gera `preview/index.html` com board de aprovacao.
+- Exibe checklist de aprovacao.
+
+5. `Artifact Builder` (dentro do MCP)
+- Gera artefato `.md` final somente com status `approved`.
+
+6. `Storage`
+- Guarda versoes do DS, manifests e historico de feedback.
+
+### Diagrama de Arquitetura
+```mermaid
+flowchart LR
+    C[Cloud Client] -->|generate request| M[MCP Server]
+    M --> E[DS Engine]
+    E --> T[Token Generator]
+    E --> K[Component Generator]
+    T --> P[Preview Service]
+    K --> P
+    P --> S[(Storage)]
+    M --> V[Validation Gates]
+    V -->|ready_for_review| C
+    C -->|approval or feedback| M
+    M -->|approved only| A[Artifact Builder .md]
+    A --> S
+    S -->|artifactPath| C
+    C -->|apply .md| L[Landing Page Runtime]
+```
+
+---
+
+## 2) Sequencia de Execucao (Cloud -> MCP -> Usuario -> Apply)
+
+```mermaid
+sequenceDiagram
+    participant U as Usuario
+    participant C as Cloud Client
+    participant M as MCP Server
+    participant E as DS Engine
+    participant P as Preview Service
+    participant A as Artifact Builder
+
+    C->>M: design-system.generate(request)
+    M->>E: build foundations + components + sections
+    E-->>M: design assets + metadata
+    M->>M: run validation gates
+    M->>P: render preview/index.html
+    P-->>M: previewPath + localUrl
+    M-->>C: status=ready_for_review + preview info
+    C-->>U: abrir preview para avaliacao
+
+    U->>C: aprovado | reprovado | aprovado_com_ajustes
+    C->>M: design-system.review(decision, feedback)
+
+    alt aprovado
+        M->>A: generate .md
+        A-->>M: artifactPath
+        M-->>C: status=approved + artifactPath
+        C->>C: apply artifact on landing page
+    else reprovado ou ajustes
+        M-->>C: status=needs_revision + requiredChanges
+    end
+```
+
+---
+
+## 3) Maquina de Estados
+
+```mermaid
+stateDiagram-v2
+    [*] --> draft
+    draft --> generating: generate request valid
+    generating --> validating: artifacts generated
+    validating --> ready_for_review: all gates pass
+    validating --> needs_revision: gate fail
+    ready_for_review --> approved: user approved
+    ready_for_review --> needs_revision: user rejected or adjustments
+    needs_revision --> generating: regenerate with feedback
+    approved --> artifact_generated: build .md
+    artifact_generated --> applied: cloud apply success
+    applied --> [*]
+```
+
+---
+
+## 4) Estrutura de Arquivos Gerados
+
+```text
+/design-system
+  /preview
+    index.html
+  /tokens
+    colors.json
+    typography.json
+    spacing.json
+    radius.json
+    elevation.json
+    breakpoints.json
+  /components
+    button.json
+    input.json
+    card.json
+    navbar.json
+    footer.json
+  /sections
+    hero.json
+    features.json
+    testimonials.json
+    faq.json
+    cta.json
+  /manifests
+    ds-manifest.json
+    validation-report.json
+    approval-log.json
+  /artifacts
+    design-system.md
+```
+
+---
+
+## 5) Contratos de Entrada e Saida (JSON)
+
+### 5.1 Requisicao de Geracao
+```json
+{
+  "action": "design-system.generate",
+  "requestId": "uuid",
+  "project": {
+    "id": "project-123",
+    "name": "Landing X",
+    "audience": "SaaS B2B",
+    "goal": "captar_leads",
+    "tone": ["moderno", "confiavel", "objetivo"]
+  },
+  "designInput": {
+    "paletteMode": "provided_or_generate",
+    "providedPalette": {
+      "primary": "#2563EB",
+      "secondary": "#0EA5E9",
+      "accent": "#22C55E"
+    },
+    "typographyMode": "provided_or_suggest",
+    "providedTypography": {
+      "display": "Poppins",
+      "body": "Inter"
+    },
+    "references": [
+      "https://example.com/reference-1"
+    ]
+  },
+  "constraints": {
+    "mobileFirst": true,
+    "accessibility": "WCAG_AA",
+    "componentsMin": 5,
+    "sectionsMin": 5
+  },
+  "version": "v0.1.0"
+}
+```
+
+### 5.2 Resposta da Geracao
+```json
+{
+  "requestId": "uuid",
+  "status": "ready_for_review",
+  "designSystemId": "ds-2026-03-04-001",
+  "version": "v0.1.0",
+  "preview": {
+    "filePath": "/design-system/preview/index.html",
+    "localUrl": "http://localhost:4173/design-system/preview/index.html"
+  },
+  "artifacts": {
+    "tokensPath": "/design-system/tokens",
+    "componentsPath": "/design-system/components",
+    "validationReportPath": "/design-system/manifests/validation-report.json"
+  },
+  "gates": {
+    "allPassed": true,
+    "failedRules": []
+  }
+}
+```
+
+### 5.3 Requisicao de Review
+```json
+{
+  "action": "design-system.review",
+  "designSystemId": "ds-2026-03-04-001",
+  "decision": "approved_with_adjustments",
+  "feedback": {
+    "colorsApproved": true,
+    "typographyApproved": false,
+    "componentsApproved": true,
+    "sectionsApproved": true,
+    "notes": [
+      "Ajustar escala de H2 e H3",
+      "Aumentar contraste do texto secundario"
+    ]
+  }
+}
+```
+
+### 5.4 Resposta de Review
+```json
+{
+  "designSystemId": "ds-2026-03-04-001",
+  "status": "needs_revision",
+  "requiredChanges": [
+    "typography.scale",
+    "semantic.text.secondary.contrast"
+  ],
+  "nextAction": "design-system.generate_revision"
+}
+```
+
+### 5.5 Resposta Final (Aprovado)
+```json
+{
+  "designSystemId": "ds-2026-03-04-001",
+  "status": "approved",
+  "artifact": {
+    "type": "md",
+    "filePath": "/design-system/artifacts/design-system.md",
+    "checksum": "sha256:..."
+  }
+}
+```
+
+---
+
+## 6) Gates de Validacao (bloqueantes)
+
+### Gate A - Estrutura minima
+- Deve existir: `tokens`, `components`, `sections`, `preview`.
+- Deve conter no minimo 5 componentes e 5 secoes.
+
+### Gate B - Tokens obrigatorios
+- Primitive tokens: cores base, spacing base, radius base, font sizes base.
+- Semantic tokens: `bg/*`, `text/*`, `border/*`, `action/*`, `feedback/*`.
+- Component tokens: pelo menos para Button, Input, Card, Navbar, Footer.
+
+### Gate C - Acessibilidade
+- Contraste minimo AA para texto principal e CTAs.
+- Foco visivel para elementos interativos.
+- Estados `hover`, `active`, `disabled`, `focus-visible`.
+
+### Gate D - Preview valido
+- `preview/index.html` gerado com:
+  - swatches + uso semantico,
+  - tipografia aplicada,
+  - galeria de componentes com estados,
+  - landing demo (Hero, Features, CTA pelo menos).
+
+### Gate E - Pronto para aplicacao
+- O artefato `.md` so pode ser gerado quando:
+  - status atual = `approved`,
+  - `validation-report.json` com `allPassed=true`.
+
+---
+
+## 7) Plano Executavel por IA (contrato operacional)
+
+```json
+{
+  "planVersion": "1.0.0",
+  "workflow": [
+    {
+      "id": "step-01-validate-input",
+      "type": "validate",
+      "input": ["project", "designInput", "constraints"],
+      "output": ["normalizedInput"],
+      "onFail": "stop_with_error"
+    },
+    {
+      "id": "step-02-generate-foundations",
+      "type": "generate",
+      "input": ["normalizedInput"],
+      "output": ["tokens/colors.json", "tokens/typography.json", "tokens/spacing.json", "tokens/radius.json", "tokens/elevation.json", "tokens/breakpoints.json"]
+    },
+    {
+      "id": "step-03-generate-components",
+      "type": "generate",
+      "input": ["tokens/*"],
+      "output": ["components/button.json", "components/input.json", "components/card.json", "components/navbar.json", "components/footer.json"]
+    },
+    {
+      "id": "step-04-generate-sections",
+      "type": "generate",
+      "input": ["components/*", "tokens/*"],
+      "output": ["sections/hero.json", "sections/features.json", "sections/testimonials.json", "sections/faq.json", "sections/cta.json"]
+    },
+    {
+      "id": "step-05-render-preview",
+      "type": "render",
+      "input": ["tokens/*", "components/*", "sections/*"],
+      "output": ["preview/index.html"]
+    },
+    {
+      "id": "step-06-run-gates",
+      "type": "validate",
+      "input": ["all_generated_files"],
+      "output": ["manifests/validation-report.json"],
+      "onFail": "set_status_needs_revision"
+    },
+    {
+      "id": "step-07-await-review",
+      "type": "human_approval",
+      "input": ["preview/index.html", "validation-report.json"],
+      "output": ["decision"]
+    },
+    {
+      "id": "step-08-generate-md",
+      "type": "generate",
+      "condition": "decision == approved",
+      "input": ["approved_design_system"],
+      "output": ["artifacts/design-system.md"]
+    }
+  ],
+  "statusPolicy": {
+    "initial": "draft",
+    "afterGenerateSuccess": "ready_for_review",
+    "afterGateFail": "needs_revision",
+    "afterApproval": "approved"
+  }
+}
+```
+
+---
+
+## 8) Especificacao do artefato `.md` (minimo)
+
+```json
+{
+  "artifactType": "design-system.md",
+  "version": "v0.1.0",
+  "designSystemId": "ds-2026-03-04-001",
+  "tokens": {
+    "colors": {},
+    "typography": {},
+    "spacing": {},
+    "radius": {},
+    "elevation": {},
+    "breakpoints": {}
+  },
+  "componentsMap": {
+    "button": {
+      "variants": ["primary", "secondary", "ghost"],
+      "classOrTokenRefs": []
+    },
+    "input": {},
+    "card": {},
+    "navbar": {},
+    "footer": {}
+  },
+  "applyInstructions": [
+    "inject_tokens",
+    "map_components",
+    "render_sections",
+    "run_post_apply_checks"
+  ],
+  "guardrails": {
+    "blockOnContrastFailure": true,
+    "blockOnMissingToken": true,
+    "blockOnMissingComponentMap": true
+  }
+}
+```
+
+---
+
+## 9) Definicao de Pronto (DoD)
+
+Para considerar a execucao concluida:
+1. Preview HTML funcional gerado.
+2. Checklist de aprovacao exibido.
+3. Validacoes bloqueantes aprovadas.
+4. Revisao humana registrada.
+5. Artefato `.md` gerado somente apos aprovacao.
+6. Tudo versionado em `ds-manifest.json`.
+
+---
+
+## 10) Nota de Qualidade
+
+"100% de acerto" em producao so e viavel quando o fluxo e **fail-safe**:
+- ou passa em todos os gates e executa,
+- ou bloqueia com erro explicito e pede revisao.
+
+Este plano foi desenhado exatamente para esse comportamento.

--- a/README.md
+++ b/README.md
@@ -207,6 +207,28 @@ This interactive command:
 - Includes dry-run mode to preview changes
 - Works with Claude Code, Cursor, Windsurf, Cline, Continue.dev, and more
 
+### Claude Code Project Bootstrap (opt-in)
+
+Enable Claude Code integration per repository:
+
+```bash
+npx @ai-coders/context claude:bootstrap
+```
+
+Local development shortcut:
+
+```bash
+npm run claude:bootstrap
+```
+
+What it adds (safe merge, idempotent):
+- `.mcp.json` with `mcpServers.ai-context` (preserves existing servers/keys)
+- `.claude/settings.json` with conservative permissions + `PreToolUse` and `Stop` hooks
+- `.claude/agents/*.md` exported from `.context/agents/*.md` (updates only managed files)
+
+How to revert:
+- Remove `.claude/` and `.mcp.json`
+
 ### Manual Configuration
 
 Alternatively, manually configure for your preferred tool.

--- a/README.md
+++ b/README.md
@@ -207,6 +207,24 @@ This interactive command:
 - Includes dry-run mode to preview changes
 - Works with Claude Code, Cursor, Windsurf, Cline, Continue.dev, and more
 
+### Streamable HTTP Mode (Codex IDE / Remote Clients)
+
+For clients that connect over HTTP instead of spawning stdio, start the MCP server in Streamable HTTP mode:
+
+```bash
+npx @ai-coders/context mcp:http --host 127.0.0.1 --port 3000 --path /mcp
+```
+
+Local development shortcut:
+
+```bash
+npm run mcp:http -- --host 127.0.0.1 --port 3000 --path /mcp
+```
+
+Endpoint:
+- `http://127.0.0.1:3000/mcp`
+- Methods supported by the MCP Streamable HTTP transport: `POST`, `GET`, `DELETE`
+
 ### Claude Code Project Bootstrap (opt-in)
 
 Enable Claude Code integration per repository:

--- a/README.md
+++ b/README.md
@@ -215,6 +215,12 @@ For clients that connect over HTTP instead of spawning stdio, start the MCP serv
 npx @ai-coders/context mcp:http --host 127.0.0.1 --port 3000 --path /mcp
 ```
 
+For remote/load-balanced deployments (for example MCP-Use), use stateless mode:
+
+```bash
+node dist/index.js mcp:http --host 0.0.0.0 --port 3000 --path /mcp --stateless --json-response
+```
+
 Local development shortcut:
 
 ```bash
@@ -224,6 +230,7 @@ npm run mcp:http -- --host 127.0.0.1 --port 3000 --path /mcp
 Endpoint:
 - `http://127.0.0.1:3000/mcp`
 - Methods supported by the MCP Streamable HTTP transport: `POST`, `GET`, `DELETE`
+- `--stateless` disables server-side session stickiness requirements for multi-instance environments
 
 ### Claude Code Project Bootstrap (opt-in)
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "build": "tsc",
     "dev": "tsx src/index.ts",
     "start": "node dist/index.js",
+    "claude:bootstrap": "tsx src/index.ts claude:bootstrap",
     "test": "jest",
     "prepublishOnly": "npm run build",
     "version": "npm run build",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "build": "tsc",
     "dev": "tsx src/index.ts",
     "start": "node dist/index.js",
+    "mcp:http": "tsx src/index.ts mcp:http",
     "claude:bootstrap": "tsx src/index.ts claude:bootstrap",
     "test": "jest",
     "prepublishOnly": "npm run build",

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,7 @@ import { ReportService } from './services/report';
 import { StackDetector } from './services/stack';
 import { QuickSyncService, QuickSyncOptions } from './services/quickSync';
 import { ReverseQuickSyncService, type MergeStrategy } from './services/reverseSync';
+import { ClaudeBootstrapService } from './services/claude';
 import { AutoAdvanceDetector } from './services/workflow/autoAdvance';
 import { getScaleName, PHASE_NAMES_PT, PHASE_NAMES_EN, ROLE_DISPLAY_NAMES, ROLE_DISPLAY_NAMES_EN, type PrevcRole, ProjectScale } from './workflow';
 import { DEFAULT_MODELS, getApiKeyFromEnv } from './services/ai/providerFactory';
@@ -538,6 +539,33 @@ program
       }
     } catch (error) {
       ui.displayError(t('errors.mcp.installFailed', { tool: tool || 'unknown' }), error as Error);
+      process.exit(1);
+    }
+  });
+
+// Claude Code Bootstrap Command (opt-in)
+program
+  .command('claude:bootstrap')
+  .description('Bootstrap Claude Code integration (opt-in): .mcp.json, .claude/settings.json, .claude/agents')
+  .argument('[repo-path]', 'Repository path', process.cwd())
+  .option('--force', 'Force-update managed ai-context MCP server config')
+  .option('--dry-run', 'Preview changes without writing')
+  .option('-v, --verbose', 'Verbose output')
+  .action(async (repoPath: string, options: any) => {
+    try {
+      const claudeBootstrapService = new ClaudeBootstrapService({
+        ui,
+        t,
+        version: VERSION,
+      });
+
+      await claudeBootstrapService.run(repoPath, {
+        force: options.force,
+        dryRun: options.dryRun,
+        verbose: options.verbose,
+      });
+    } catch (error) {
+      ui.displayError('Failed to bootstrap Claude Code integration', error as Error);
       process.exit(1);
     }
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -492,6 +492,8 @@ program
   .option('--host <host>', 'Host to bind', '127.0.0.1')
   .option('--port <number>', 'Port to bind', (value: string) => parseInt(value, 10), 3000)
   .option('--path <path>', 'MCP endpoint path', '/mcp')
+  .option('--json-response', 'Return JSON responses for Streamable HTTP requests (recommended for compatibility)', true)
+  .option('--stateless', 'Disable session state (recommended for load-balanced remote deployments)')
   .option('-v, --verbose', 'Enable verbose logging to stderr')
   .action(async (options: any) => {
     try {
@@ -500,6 +502,8 @@ program
         host: options.host,
         port: options.port,
         endpointPath: options.path,
+        jsonResponse: options.jsonResponse !== false,
+        stateless: Boolean(options.stateless),
         verbose: options.verbose,
       });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ import { PlanService } from './services/plan/planService';
 import { SyncService } from './services/sync/syncService';
 import { ImportRulesService, ImportAgentsService } from './services/import';
 import { ServeService } from './services/serve';
-import { startMCPServer, MCPInstallService } from './services/mcp';
+import { startMCPServer, startMCPHttpServer, MCPInstallService } from './services/mcp';
 import { StateDetector } from './services/state';
 import { UpdateService } from './services/update';
 import { WorkflowService, WorkflowServiceDependencies } from './services/workflow';
@@ -45,7 +45,7 @@ import {
 import { VERSION, PACKAGE_NAME } from './version';
 
 const rawArgs = process.argv.slice(2);
-const isMcpCommand = rawArgs.includes('mcp');
+const isMcpCommand = rawArgs.includes('mcp') || rawArgs.includes('mcp:http');
 
 // Determine if we're in interactive mode (no command args, only flags like --lang)
 const isInteractiveMode = rawArgs.every(arg =>
@@ -480,6 +480,41 @@ program
     } catch (error) {
       if (options.verbose) {
         process.stderr.write(`[mcp] Error: ${error}\n`);
+      }
+      process.exit(1);
+    }
+  });
+
+program
+  .command('mcp:http')
+  .description('Start MCP Streamable HTTP server for IDE integrations (Codex, remote clients)')
+  .option('-r, --repo-path <path>', 'Default repository path for tools')
+  .option('--host <host>', 'Host to bind', '127.0.0.1')
+  .option('--port <number>', 'Port to bind', (value: string) => parseInt(value, 10), 3000)
+  .option('--path <path>', 'MCP endpoint path', '/mcp')
+  .option('-v, --verbose', 'Enable verbose logging to stderr')
+  .action(async (options: any) => {
+    try {
+      const server = await startMCPHttpServer({
+        repoPath: options.repoPath,
+        host: options.host,
+        port: options.port,
+        endpointPath: options.path,
+        verbose: options.verbose,
+      });
+
+      process.on('SIGINT', async () => {
+        await server.stop();
+        process.exit(0);
+      });
+
+      process.on('SIGTERM', async () => {
+        await server.stop();
+        process.exit(0);
+      });
+    } catch (error) {
+      if (options.verbose) {
+        process.stderr.write(`[mcp:http] Error: ${error}\n`);
       }
       process.exit(1);
     }

--- a/src/services/claude/claudeBootstrapService.test.ts
+++ b/src/services/claude/claudeBootstrapService.test.ts
@@ -1,0 +1,154 @@
+import * as os from 'os';
+import * as path from 'path';
+import * as fs from 'fs-extra';
+import type { CLIInterface } from '../../utils/cliUI';
+import { ClaudeBootstrapService } from './claudeBootstrapService';
+
+const PRE_TOOL_HOOK_COMMAND = 'node .claude/hooks/pre-tool-use.js';
+const STOP_HOOK_COMMAND = 'node .claude/hooks/stop.js';
+const GENERATED_MARKER = '<!-- generated-by: ai-coders-context claude -->';
+
+const createMockUI = (): CLIInterface => ({
+  displayWelcome: jest.fn(),
+  displayError: jest.fn(),
+  displaySuccess: jest.fn(),
+  displayInfo: jest.fn(),
+  displayWarning: jest.fn(),
+  displayList: jest.fn(),
+  displayTable: jest.fn(),
+  displayJson: jest.fn(),
+  displayProjectConfiguration: jest.fn(),
+  displayFileTypeDistribution: jest.fn(),
+  displayGenerationSummary: jest.fn(),
+  startSpinner: jest.fn(),
+  updateSpinner: jest.fn(),
+  stopSpinner: jest.fn(),
+  displayAnalysisComplete: jest.fn(),
+  displayBox: jest.fn(),
+  displaySection: jest.fn(),
+  displayStep: jest.fn(),
+  displayDiff: jest.fn(),
+  displaySkillHeader: jest.fn(),
+  displaySkillDefinition: jest.fn(),
+  displaySkillExamples: jest.fn(),
+  displaySkillContent: jest.fn(),
+} as unknown as CLIInterface);
+
+const mockTranslate = (key: string) => key;
+
+describe('ClaudeBootstrapService', () => {
+  let tempDir: string;
+  let service: ClaudeBootstrapService;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'claude-bootstrap-test-'));
+    service = new ClaudeBootstrapService({
+      ui: createMockUI(),
+      t: mockTranslate,
+      version: '1.0.0',
+    });
+
+    await fs.ensureDir(path.join(tempDir, '.context', 'agents'));
+    await fs.writeFile(
+      path.join(tempDir, '.context', 'agents', 'feature-developer.md'),
+      `---
+type: agent
+name: Feature Developer
+description: Implements features
+---
+
+# Feature Developer
+`,
+      'utf-8'
+    );
+  });
+
+  afterEach(async () => {
+    await fs.remove(tempDir);
+  });
+
+  it('creates .mcp.json, .claude/settings.json and Claude agents on first run', async () => {
+    await service.run(tempDir);
+
+    const mcpPath = path.join(tempDir, '.mcp.json');
+    const settingsPath = path.join(tempDir, '.claude', 'settings.json');
+    const agentPath = path.join(tempDir, '.claude', 'agents', 'feature-developer.md');
+    const preToolHookPath = path.join(tempDir, '.claude', 'hooks', 'pre-tool-use.js');
+    const stopHookPath = path.join(tempDir, '.claude', 'hooks', 'stop.js');
+    const gitignorePath = path.join(tempDir, '.gitignore');
+
+    expect(await fs.pathExists(mcpPath)).toBe(true);
+    expect(await fs.pathExists(settingsPath)).toBe(true);
+    expect(await fs.pathExists(agentPath)).toBe(true);
+    expect(await fs.pathExists(preToolHookPath)).toBe(true);
+    expect(await fs.pathExists(stopHookPath)).toBe(true);
+    expect(await fs.pathExists(gitignorePath)).toBe(true);
+
+    const mcpConfig = await fs.readJson(mcpPath);
+    expect(mcpConfig.mcpServers).toBeDefined();
+    expect(mcpConfig.mcpServers['ai-context']).toBeDefined();
+
+    const settingsConfig = await fs.readJson(settingsPath);
+    const preToolCommands = (settingsConfig.hooks?.PreToolUse || [])
+      .flatMap((rule: any) => rule.hooks || [])
+      .map((hook: any) => hook.command);
+    const stopCommands = (settingsConfig.hooks?.Stop || [])
+      .flatMap((rule: any) => rule.hooks || [])
+      .map((hook: any) => hook.command);
+
+    expect(preToolCommands).toContain(PRE_TOOL_HOOK_COMMAND);
+    expect(stopCommands).toContain(STOP_HOOK_COMMAND);
+
+    const agentContent = await fs.readFile(agentPath, 'utf-8');
+    expect(agentContent).toContain(GENERATED_MARKER);
+    expect(agentContent).toContain('name: Feature Developer');
+    expect(agentContent).toContain('description: Implements features');
+
+    const gitignoreContent = await fs.readFile(gitignorePath, 'utf-8');
+    expect(gitignoreContent).toContain('.claude/settings.local.json');
+  });
+
+  it('is idempotent and does not duplicate MCP/hooks entries', async () => {
+    await service.run(tempDir);
+    const secondRun = await service.run(tempDir);
+
+    const mcpConfig = await fs.readJson(path.join(tempDir, '.mcp.json'));
+    expect(Object.keys(mcpConfig.mcpServers).filter((key) => key === 'ai-context')).toHaveLength(1);
+
+    const settingsConfig = await fs.readJson(path.join(tempDir, '.claude', 'settings.json'));
+    const preToolCommands = (settingsConfig.hooks?.PreToolUse || [])
+      .flatMap((rule: any) => rule.hooks || [])
+      .filter((hook: any) => hook.command === PRE_TOOL_HOOK_COMMAND);
+    const stopCommands = (settingsConfig.hooks?.Stop || [])
+      .flatMap((rule: any) => rule.hooks || [])
+      .filter((hook: any) => hook.command === STOP_HOOK_COMMAND);
+
+    expect(preToolCommands).toHaveLength(1);
+    expect(stopCommands).toHaveLength(1);
+    expect(secondRun.agentsSkipped).toBeGreaterThan(0);
+  });
+
+  it('merges with preexisting .mcp.json without losing unrelated configuration', async () => {
+    const preexistingMcp = {
+      customRootKey: true,
+      mcpServers: {
+        existing: {
+          command: 'node',
+          args: ['some-existing-server.js'],
+        },
+        'ai-context': {
+          command: 'custom',
+          args: ['custom-mcp'],
+        },
+      },
+    };
+    await fs.writeJson(path.join(tempDir, '.mcp.json'), preexistingMcp, { spaces: 2 });
+
+    await service.run(tempDir);
+
+    const mergedConfig = await fs.readJson(path.join(tempDir, '.mcp.json'));
+    expect(mergedConfig.customRootKey).toBe(true);
+    expect(mergedConfig.mcpServers.existing).toEqual(preexistingMcp.mcpServers.existing);
+    expect(mergedConfig.mcpServers['ai-context']).toEqual(preexistingMcp.mcpServers['ai-context']);
+  });
+});

--- a/src/services/claude/claudeBootstrapService.ts
+++ b/src/services/claude/claudeBootstrapService.ts
@@ -1,0 +1,723 @@
+import * as path from 'path';
+import * as fs from 'fs-extra';
+import {
+  BaseDependencies,
+  OperationResult,
+  createEmptyResult,
+  addError,
+} from '../shared';
+
+type FileAction = 'created' | 'updated' | 'unchanged';
+
+export type ClaudeBootstrapServiceDependencies = BaseDependencies;
+
+export interface ClaudeBootstrapOptions {
+  force?: boolean;
+  dryRun?: boolean;
+  verbose?: boolean;
+}
+
+export interface ClaudeBootstrapResult extends OperationResult {
+  repoPath: string;
+  mcpPath: string;
+  settingsPath: string;
+  mcpAction: FileAction;
+  settingsAction: FileAction;
+  agentsCreated: number;
+  agentsUpdated: number;
+  agentsSkipped: number;
+  hookScriptsWritten: number;
+  gitignoreUpdated: boolean;
+  dryRun: boolean;
+}
+
+const GENERATED_MARKER = '<!-- generated-by: ai-coders-context claude -->';
+
+const MCP_SERVER_NAME = 'ai-context';
+const MCP_SERVER_CONFIG = {
+  command: 'npx',
+  args: ['-y', '@ai-coders/context@latest', 'mcp'],
+};
+
+const SETTINGS_LOCAL_GITIGNORE_ENTRY = '.claude/settings.local.json';
+
+const PRE_TOOL_HOOK_COMMAND = 'node .claude/hooks/pre-tool-use.js';
+const STOP_HOOK_COMMAND = 'node .claude/hooks/stop.js';
+
+const PRE_TOOL_HOOK_RELATIVE_PATH = path.join('.claude', 'hooks', 'pre-tool-use.js');
+const STOP_HOOK_RELATIVE_PATH = path.join('.claude', 'hooks', 'stop.js');
+
+const REQUIRED_DENY_PATTERNS = [
+  'Bash(rm -rf*)',
+  'Bash(del /f /s*)',
+  'Bash(curl *|* sh*)',
+  'Bash(iwr *|* iex*)',
+  'Edit(.env*)',
+  'Write(.env*)',
+  'Edit(**/*.pem)',
+  'Write(**/*.pem)',
+  'Edit(**/id_rsa*)',
+  'Write(**/id_rsa*)',
+  'Edit(**/*credentials*)',
+  'Write(**/*credentials*)',
+  'Edit(**/*secrets*)',
+  'Write(**/*secrets*)',
+];
+
+const REQUIRED_ASK_PATTERNS = [
+  'Bash(*)',
+  'Edit(*)',
+  'Write(*)',
+];
+
+interface MergeJsonResult {
+  action: FileAction;
+  wroteFile: boolean;
+}
+
+interface HookScriptWriteResult {
+  wroteFile: boolean;
+  skipped: boolean;
+}
+
+export class ClaudeBootstrapService {
+  constructor(private deps: ClaudeBootstrapServiceDependencies) {}
+
+  async run(repoPath: string, options: ClaudeBootstrapOptions = {}): Promise<ClaudeBootstrapResult> {
+    const absoluteRepoPath = path.resolve(repoPath);
+    const result: ClaudeBootstrapResult = {
+      ...createEmptyResult(),
+      repoPath: absoluteRepoPath,
+      mcpPath: path.join(absoluteRepoPath, '.mcp.json'),
+      settingsPath: path.join(absoluteRepoPath, '.claude', 'settings.json'),
+      mcpAction: 'unchanged',
+      settingsAction: 'unchanged',
+      agentsCreated: 0,
+      agentsUpdated: 0,
+      agentsSkipped: 0,
+      hookScriptsWritten: 0,
+      gitignoreUpdated: false,
+      dryRun: Boolean(options.dryRun),
+    };
+
+    try {
+      const mcpMerge = await this.mergeMcpConfig(absoluteRepoPath, options);
+      result.mcpAction = mcpMerge.action;
+      if (mcpMerge.wroteFile) {
+        result.filesCreated += 1;
+      } else {
+        result.filesSkipped += 1;
+      }
+
+      const settingsMerge = await this.mergeClaudeSettings(absoluteRepoPath, options);
+      result.settingsAction = settingsMerge.action;
+      if (settingsMerge.wroteFile) {
+        result.filesCreated += 1;
+      } else {
+        result.filesSkipped += 1;
+      }
+
+      const hookResults = await this.writeHookScripts(absoluteRepoPath, options);
+      result.hookScriptsWritten = hookResults.filter((item) => item.wroteFile).length;
+      result.filesCreated += result.hookScriptsWritten;
+      result.filesSkipped += hookResults.filter((item) => !item.wroteFile).length;
+
+      const agentResult = await this.exportClaudeAgents(absoluteRepoPath, options);
+      result.agentsCreated = agentResult.created;
+      result.agentsUpdated = agentResult.updated;
+      result.agentsSkipped = agentResult.skipped;
+      result.filesCreated += agentResult.created + agentResult.updated;
+      result.filesSkipped += agentResult.skipped;
+
+      const gitignoreUpdated = await this.ensureLocalSettingsIgnored(absoluteRepoPath, options);
+      result.gitignoreUpdated = gitignoreUpdated;
+      if (gitignoreUpdated) {
+        result.filesCreated += 1;
+      } else {
+        result.filesSkipped += 1;
+      }
+
+      this.logSummary(result);
+      return result;
+    } catch (error) {
+      addError(result, 'claude:bootstrap', error);
+      throw error;
+    }
+  }
+
+  private async mergeMcpConfig(
+    repoPath: string,
+    options: ClaudeBootstrapOptions
+  ): Promise<MergeJsonResult> {
+    const mcpPath = path.join(repoPath, '.mcp.json');
+    const existing = await this.readJsonFile(mcpPath);
+    const output = this.asObject(existing.data);
+    const mcpServers = this.asObject(output.mcpServers);
+    output.mcpServers = mcpServers;
+
+    const existingServer = mcpServers[MCP_SERVER_NAME];
+    let action: FileAction = 'unchanged';
+
+    if (!this.isObject(existingServer)) {
+      mcpServers[MCP_SERVER_NAME] = { ...MCP_SERVER_CONFIG };
+      action = existing.exists ? 'updated' : 'created';
+    } else if (options.force) {
+      if (!this.deepEqual(existingServer, MCP_SERVER_CONFIG)) {
+        mcpServers[MCP_SERVER_NAME] = { ...MCP_SERVER_CONFIG };
+        action = 'updated';
+      }
+    }
+
+    if (action === 'unchanged') {
+      return { action, wroteFile: false };
+    }
+
+    const wroteFile = await this.writeJsonFile(mcpPath, output, options);
+    return { action, wroteFile };
+  }
+
+  private async mergeClaudeSettings(
+    repoPath: string,
+    options: ClaudeBootstrapOptions
+  ): Promise<MergeJsonResult> {
+    const settingsPath = path.join(repoPath, '.claude', 'settings.json');
+    const existing = await this.readJsonFile(settingsPath);
+    const output = this.asObject(existing.data);
+
+    output.permissions = this.mergePermissions(output.permissions);
+    output.hooks = this.mergeHooks(output.hooks);
+
+    const action: FileAction = existing.exists
+      ? (this.deepEqual(existing.data, output) ? 'unchanged' : 'updated')
+      : 'created';
+
+    if (action === 'unchanged') {
+      return { action, wroteFile: false };
+    }
+
+    const wroteFile = await this.writeJsonFile(settingsPath, output, options);
+    return { action, wroteFile };
+  }
+
+  private mergePermissions(value: unknown): Record<string, unknown> {
+    const permissions = this.asObject(value);
+    const deny = this.uniqueStrings([
+      ...this.toStringArray(permissions.deny),
+      ...REQUIRED_DENY_PATTERNS,
+    ]);
+    const ask = this.uniqueStrings([
+      ...this.toStringArray(permissions.ask),
+      ...REQUIRED_ASK_PATTERNS,
+    ]);
+
+    const merged: Record<string, unknown> = {
+      ...permissions,
+      deny,
+      ask,
+    };
+
+    return merged;
+  }
+
+  private mergeHooks(value: unknown): Record<string, unknown> {
+    const hooks = this.asObject(value);
+    const preToolUse = this.ensureCommandHook(
+      this.toObjectArray(hooks.PreToolUse),
+      PRE_TOOL_HOOK_COMMAND
+    );
+    const stop = this.ensureCommandHook(
+      this.toObjectArray(hooks.Stop),
+      STOP_HOOK_COMMAND
+    );
+
+    return {
+      ...hooks,
+      PreToolUse: preToolUse,
+      Stop: stop,
+    };
+  }
+
+  private ensureCommandHook(
+    hookRules: Array<Record<string, unknown>>,
+    command: string
+  ): Array<Record<string, unknown>> {
+    const hasHook = hookRules.some((rule) => {
+      const hooks = this.toObjectArray(rule.hooks);
+      return hooks.some((hook) => hook.command === command);
+    });
+
+    if (hasHook) {
+      return hookRules;
+    }
+
+    return [
+      ...hookRules,
+      {
+        matcher: '*',
+        hooks: [
+          {
+            type: 'command',
+            command,
+          },
+        ],
+      },
+    ];
+  }
+
+  private async writeHookScripts(
+    repoPath: string,
+    options: ClaudeBootstrapOptions
+  ): Promise<HookScriptWriteResult[]> {
+    const preToolResult = await this.writeManagedFile(
+      path.join(repoPath, PRE_TOOL_HOOK_RELATIVE_PATH),
+      this.buildPreToolUseHookScript(),
+      options
+    );
+    const stopResult = await this.writeManagedFile(
+      path.join(repoPath, STOP_HOOK_RELATIVE_PATH),
+      this.buildStopHookScript(),
+      options
+    );
+
+    return [preToolResult, stopResult];
+  }
+
+  private async exportClaudeAgents(
+    repoPath: string,
+    options: ClaudeBootstrapOptions
+  ): Promise<{ created: number; updated: number; skipped: number }> {
+    const sourceDir = path.join(repoPath, '.context', 'agents');
+    const targetDir = path.join(repoPath, '.claude', 'agents');
+    const output = { created: 0, updated: 0, skipped: 0 };
+
+    if (!(await fs.pathExists(sourceDir))) {
+      return output;
+    }
+
+    const entries = await fs.readdir(sourceDir);
+    const agentFiles = entries.filter((file) => file.endsWith('.md') && file.toLowerCase() !== 'readme.md');
+
+    if (agentFiles.length === 0) {
+      return output;
+    }
+
+    if (!options.dryRun) {
+      await fs.ensureDir(targetDir);
+    }
+
+    for (const filename of agentFiles) {
+      const sourcePath = path.join(sourceDir, filename);
+      const targetPath = path.join(targetDir, filename);
+      const sourceContent = await fs.readFile(sourcePath, 'utf-8');
+      const targetContent = this.buildManagedAgentContent(sourceContent, filename);
+
+      if (!(await fs.pathExists(targetPath))) {
+        if (!options.dryRun) {
+          await fs.writeFile(targetPath, targetContent, 'utf-8');
+        }
+        output.created += 1;
+        continue;
+      }
+
+      const existingTarget = await fs.readFile(targetPath, 'utf-8');
+      const isManaged = existingTarget.includes(GENERATED_MARKER);
+      if (!isManaged) {
+        output.skipped += 1;
+        continue;
+      }
+
+      if (existingTarget === targetContent) {
+        output.skipped += 1;
+        continue;
+      }
+
+      if (!options.dryRun) {
+        await fs.writeFile(targetPath, targetContent, 'utf-8');
+      }
+      output.updated += 1;
+    }
+
+    return output;
+  }
+
+  private async ensureLocalSettingsIgnored(
+    repoPath: string,
+    options: ClaudeBootstrapOptions
+  ): Promise<boolean> {
+    const gitignorePath = path.join(repoPath, '.gitignore');
+    const exists = await fs.pathExists(gitignorePath);
+    const content = exists ? await fs.readFile(gitignorePath, 'utf-8') : '';
+    const lines = content.split(/\r?\n/);
+
+    if (lines.some((line) => line.trim() === SETTINGS_LOCAL_GITIGNORE_ENTRY)) {
+      return false;
+    }
+
+    const next = content.length > 0 && !content.endsWith('\n')
+      ? `${content}\n${SETTINGS_LOCAL_GITIGNORE_ENTRY}\n`
+      : `${content}${SETTINGS_LOCAL_GITIGNORE_ENTRY}\n`;
+
+    if (!options.dryRun) {
+      await fs.writeFile(gitignorePath, next, 'utf-8');
+    }
+
+    return true;
+  }
+
+  private buildManagedAgentContent(content: string, filename: string): string {
+    const normalized = content.replace(/\r\n/g, '\n').replace(/^\uFEFF/, '');
+    const frontmatterEnsured = this.ensureAgentFrontmatter(normalized, filename);
+    const withTrailingNewline = frontmatterEnsured.endsWith('\n')
+      ? frontmatterEnsured
+      : `${frontmatterEnsured}\n`;
+
+    return `${GENERATED_MARKER}\n${withTrailingNewline}`;
+  }
+
+  private ensureAgentFrontmatter(content: string, filename: string): string {
+    const lines = content.split('\n');
+    const derivedName = this.toAgentName(filename);
+    const derivedDescription = `Claude Code subagent for ${derivedName.toLowerCase()} tasks`;
+
+    if (lines[0]?.trim() === '---') {
+      const endIndex = lines.findIndex((line, index) => index > 0 && line.trim() === '---');
+      if (endIndex > 0) {
+        const frontmatterLines = lines.slice(1, endIndex);
+        const body = lines.slice(endIndex + 1).join('\n').replace(/^\n+/, '');
+        const hasName = frontmatterLines.some((line) => /^\s*name:\s*/i.test(line));
+        const hasDescription = frontmatterLines.some((line) => /^\s*description:\s*/i.test(line));
+
+        if (!hasName) {
+          frontmatterLines.unshift(`name: ${this.toYamlString(derivedName)}`);
+        }
+        if (!hasDescription) {
+          frontmatterLines.push(`description: ${this.toYamlString(derivedDescription)}`);
+        }
+
+        return ['---', ...frontmatterLines, '---', '', body].join('\n');
+      }
+    }
+
+    const body = content.replace(/^\n+/, '');
+    return [
+      '---',
+      `name: ${this.toYamlString(derivedName)}`,
+      `description: ${this.toYamlString(derivedDescription)}`,
+      '---',
+      '',
+      body,
+    ].join('\n');
+  }
+
+  private toAgentName(filename: string): string {
+    const slug = filename.replace(/\.md$/i, '');
+    return slug
+      .split('-')
+      .filter(Boolean)
+      .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+      .join(' ');
+  }
+
+  private toYamlString(value: string): string {
+    return `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+  }
+
+  private async writeManagedFile(
+    filePath: string,
+    content: string,
+    options: ClaudeBootstrapOptions
+  ): Promise<HookScriptWriteResult> {
+    const exists = await fs.pathExists(filePath);
+
+    if (exists) {
+      const existingContent = await fs.readFile(filePath, 'utf-8');
+      const isManaged = existingContent.includes(GENERATED_MARKER);
+      if (!isManaged) {
+        return { wroteFile: false, skipped: true };
+      }
+      if (existingContent === content) {
+        return { wroteFile: false, skipped: true };
+      }
+    }
+
+    if (!options.dryRun) {
+      await fs.ensureDir(path.dirname(filePath));
+      await fs.writeFile(filePath, content, 'utf-8');
+    }
+
+    return { wroteFile: true, skipped: false };
+  }
+
+  private buildPreToolUseHookScript(): string {
+    return `#!/usr/bin/env node
+${GENERATED_MARKER}
+'use strict';
+
+function readStdin() {
+  return new Promise((resolve) => {
+    let data = '';
+    process.stdin.setEncoding('utf8');
+    process.stdin.on('data', (chunk) => { data += chunk; });
+    process.stdin.on('end', () => resolve(data));
+    process.stdin.on('error', () => resolve(''));
+  });
+}
+
+function get(obj, path) {
+  return path.split('.').reduce((acc, key) => {
+    if (acc && typeof acc === 'object' && key in acc) return acc[key];
+    return undefined;
+  }, obj);
+}
+
+function includesSensitiveValue(value) {
+  const patterns = [
+    /(^|[\\\\/])\\.env(\\.|$)/i,
+    /\\.pem$/i,
+    /(^|[\\\\/])id_rsa(\\.|$|_)/i,
+    /credentials/i,
+    /secrets/i,
+  ];
+  return patterns.some((pattern) => pattern.test(value));
+}
+
+function block(message) {
+  process.stderr.write('[claude-guardrails] ' + message + '\\n');
+  process.exit(2);
+}
+
+(async () => {
+  const raw = await readStdin();
+  let payload = {};
+  try {
+    payload = raw ? JSON.parse(raw) : {};
+  } catch {
+    process.exit(0);
+  }
+
+  const toolName = String(
+    get(payload, 'tool_name') ||
+    get(payload, 'toolName') ||
+    get(payload, 'tool.name') ||
+    ''
+  );
+  const command = String(
+    get(payload, 'tool_input.command') ||
+    get(payload, 'input.command') ||
+    get(payload, 'command') ||
+    ''
+  );
+  const filePath = String(
+    get(payload, 'tool_input.file_path') ||
+    get(payload, 'tool_input.path') ||
+    get(payload, 'input.file_path') ||
+    get(payload, 'input.path') ||
+    ''
+  );
+
+  const destructivePatterns = [
+    /\\brm\\s+-rf\\b/i,
+    /\\bdel\\s+\\/f\\s+\\/s\\b/i,
+    /\\bcurl\\b[^\\n|]*\\|\\s*(sh|bash)\\b/i,
+    /\\biwr\\b[^\\n|]*\\|\\s*iex\\b/i,
+  ];
+  if (destructivePatterns.some((pattern) => pattern.test(command))) {
+    block('Blocked dangerous command in PreToolUse: ' + command);
+  }
+
+  const sensitiveInCommand = includesSensitiveValue(command);
+  const sensitiveInPath = includesSensitiveValue(filePath);
+  if (sensitiveInCommand || sensitiveInPath) {
+    block('Blocked access to sensitive file or credential-like path in PreToolUse.');
+  }
+
+  const writeLikeTool = /^(write|edit|multiedit|bash)$/i.test(toolName);
+  if (writeLikeTool && includesSensitiveValue(filePath)) {
+    block('Blocked write/edit to sensitive file in PreToolUse: ' + filePath);
+  }
+
+  process.exit(0);
+})();
+`;
+  }
+
+  private buildStopHookScript(): string {
+    return `#!/usr/bin/env node
+${GENERATED_MARKER}
+'use strict';
+
+const { execSync } = require('child_process');
+
+function readStdin() {
+  return new Promise((resolve) => {
+    let data = '';
+    process.stdin.setEncoding('utf8');
+    process.stdin.on('data', (chunk) => { data += chunk; });
+    process.stdin.on('end', () => resolve(data));
+    process.stdin.on('error', () => resolve(''));
+  });
+}
+
+function get(obj, path) {
+  return path.split('.').reduce((acc, key) => {
+    if (acc && typeof acc === 'object' && key in acc) return acc[key];
+    return undefined;
+  }, obj);
+}
+
+function getChangedFiles() {
+  try {
+    const output = execSync('git status --porcelain', { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] });
+    return output
+      .split(/\\r?\\n/)
+      .map((line) => line.trim())
+      .filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+function extractAssistantText(payload) {
+  const candidates = [
+    get(payload, 'response.output_text'),
+    get(payload, 'output_text'),
+    get(payload, 'message'),
+    get(payload, 'text'),
+    get(payload, 'completion'),
+  ];
+  return String(candidates.find((item) => typeof item === 'string' && item.trim().length > 0) || '');
+}
+
+function missingChecklist(text) {
+  const hasSummary = /(summary|resumo|changes|mudancas|o que mudou)/i.test(text);
+  const hasFiles = /(files|arquivos|alterados|modified)/i.test(text);
+  const hasTests = /(test|tests|como testar|how to test|npm test|pnpm test|yarn test)/i.test(text);
+  return !(hasSummary && hasFiles && hasTests);
+}
+
+(async () => {
+  const changedFiles = getChangedFiles();
+  if (changedFiles.length === 0) {
+    process.exit(0);
+  }
+
+  const raw = await readStdin();
+  let payload = {};
+  try {
+    payload = raw ? JSON.parse(raw) : {};
+  } catch {
+    process.exit(0);
+  }
+
+  const stopReason = String(get(payload, 'stop_reason') || get(payload, 'stopReason') || '').toLowerCase();
+  if (stopReason && !/(end|stop|complete|done)/.test(stopReason)) {
+    process.exit(0);
+  }
+
+  const assistantText = extractAssistantText(payload).trim();
+  if (assistantText.length < 120) {
+    process.exit(0);
+  }
+
+  if (missingChecklist(assistantText)) {
+    process.stderr.write('[claude-guardrails] Stop checklist required when changes exist:\\n');
+    process.stderr.write('1) resumo do que mudou\\n2) arquivos alterados\\n3) como testar\\n');
+    process.exit(2);
+  }
+
+  process.exit(0);
+})();
+`;
+  }
+
+  private async readJsonFile(filePath: string): Promise<{ exists: boolean; data: unknown }> {
+    const exists = await fs.pathExists(filePath);
+    if (!exists) {
+      return { exists: false, data: {} };
+    }
+
+    const raw = await fs.readFile(filePath, 'utf-8');
+    try {
+      const parsed = JSON.parse(raw);
+      return { exists: true, data: parsed };
+    } catch {
+      throw new Error(`Invalid JSON at ${filePath}`);
+    }
+  }
+
+  private async writeJsonFile(
+    filePath: string,
+    data: Record<string, unknown>,
+    options: ClaudeBootstrapOptions
+  ): Promise<boolean> {
+    if (options.dryRun) {
+      return true;
+    }
+
+    await fs.ensureDir(path.dirname(filePath));
+    await fs.writeFile(filePath, this.stringifyJson(data), 'utf-8');
+    return true;
+  }
+
+  private stringifyJson(value: unknown): string {
+    return `${JSON.stringify(value, null, 2)}\n`;
+  }
+
+  private isObject(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+  }
+
+  private asObject(value: unknown): Record<string, unknown> {
+    return this.isObject(value) ? { ...value } : {};
+  }
+
+  private toStringArray(value: unknown): string[] {
+    if (!Array.isArray(value)) {
+      return [];
+    }
+    return value.filter((entry): entry is string => typeof entry === 'string');
+  }
+
+  private toObjectArray(value: unknown): Array<Record<string, unknown>> {
+    if (!Array.isArray(value)) {
+      return [];
+    }
+    return value.filter((item): item is Record<string, unknown> => this.isObject(item));
+  }
+
+  private uniqueStrings(values: string[]): string[] {
+    return [...new Set(values)];
+  }
+
+  private deepEqual(left: unknown, right: unknown): boolean {
+    return this.stableStringify(left) === this.stableStringify(right);
+  }
+
+  private stableStringify(value: unknown): string {
+    return JSON.stringify(this.sortRecursively(value));
+  }
+
+  private sortRecursively(value: unknown): unknown {
+    if (Array.isArray(value)) {
+      return value.map((item) => this.sortRecursively(item));
+    }
+    if (!this.isObject(value)) {
+      return value;
+    }
+    const sortedEntries = Object.entries(value).sort(([left], [right]) => left.localeCompare(right));
+    return Object.fromEntries(sortedEntries.map(([key, item]) => [key, this.sortRecursively(item)]));
+  }
+
+  private logSummary(result: ClaudeBootstrapResult): void {
+    const details = [
+      `mcp=${result.mcpAction}`,
+      `settings=${result.settingsAction}`,
+      `agents(created=${result.agentsCreated}, updated=${result.agentsUpdated}, skipped=${result.agentsSkipped})`,
+      `hooks=${result.hookScriptsWritten}`,
+      `gitignore=${result.gitignoreUpdated ? 'updated' : 'unchanged'}`,
+    ];
+
+    this.deps.ui.displaySuccess('Claude Code bootstrap completed');
+    this.deps.ui.displayInfo('Summary', details.join(', '));
+  }
+}

--- a/src/services/claude/index.ts
+++ b/src/services/claude/index.ts
@@ -1,0 +1,6 @@
+export { ClaudeBootstrapService } from './claudeBootstrapService';
+export type {
+  ClaudeBootstrapServiceDependencies,
+  ClaudeBootstrapOptions,
+  ClaudeBootstrapResult,
+} from './claudeBootstrapService';

--- a/src/services/mcp/index.ts
+++ b/src/services/mcp/index.ts
@@ -1,5 +1,10 @@
 export { AIContextMCPServer, startMCPServer, type MCPServerOptions } from './mcpServer';
 export {
+  AIContextMCPHttpServer,
+  startMCPHttpServer,
+  type MCPHttpServerOptions,
+} from './mcpHttpServer';
+export {
   MCPInstallService,
   type MCPInstallServiceDependencies,
   type MCPInstallOptions,

--- a/src/services/mcp/mcpHttpServer.test.ts
+++ b/src/services/mcp/mcpHttpServer.test.ts
@@ -37,4 +37,121 @@ describe('AIContextMCPHttpServer', () => {
     };
     expect(payload.error?.message).toContain('No valid session ID provided');
   });
+
+  it('returns JSON initialize response by default in HTTP mode', async () => {
+    server = new AIContextMCPHttpServer({
+      host: '127.0.0.1',
+      port: 0,
+      endpointPath: '/mcp',
+      verbose: false,
+    });
+
+    await server.start();
+    const port = server.getPort();
+
+    const response = await fetch(`http://127.0.0.1:${port}/mcp`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'accept': 'application/json, text/event-stream',
+      },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'initialize',
+        params: {
+          protocolVersion: '2025-11-25',
+          capabilities: {},
+          clientInfo: { name: 'test-client', version: '1.0.0' },
+        },
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('content-type')).toContain('application/json');
+    expect(response.headers.get('mcp-session-id')).toBeTruthy();
+  });
+
+  it('exposes root status endpoint', async () => {
+    server = new AIContextMCPHttpServer({
+      host: '127.0.0.1',
+      port: 0,
+      endpointPath: '/mcp',
+      verbose: false,
+    });
+
+    await server.start();
+    const port = server.getPort();
+
+    const response = await fetch(`http://127.0.0.1:${port}/`, {
+      method: 'GET',
+    });
+
+    expect(response.status).toBe(200);
+    const payload = await response.json() as {
+      endpoint?: string;
+      transport?: string;
+      jsonResponse?: boolean;
+      mode?: string;
+    };
+    expect(payload.endpoint).toBe('/mcp');
+    expect(payload.transport).toBe('streamable-http');
+    expect(payload.jsonResponse).toBe(true);
+    expect(payload.mode).toBe('stateful');
+  });
+
+  it('supports stateless mode for remote/load-balanced clients', async () => {
+    server = new AIContextMCPHttpServer({
+      host: '127.0.0.1',
+      port: 0,
+      endpointPath: '/mcp',
+      stateless: true,
+      verbose: false,
+    });
+
+    await server.start();
+    const port = server.getPort();
+    const endpoint = `http://127.0.0.1:${port}/mcp`;
+
+    const initializeResponse = await fetch(endpoint, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'accept': 'application/json, text/event-stream',
+      },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'initialize',
+        params: {
+          protocolVersion: '2025-11-25',
+          capabilities: {},
+          clientInfo: { name: 'test-client', version: '1.0.0' },
+        },
+      }),
+    });
+
+    expect(initializeResponse.status).toBe(200);
+    expect(initializeResponse.headers.get('mcp-session-id')).toBeNull();
+    await initializeResponse.text();
+
+    const toolsResponse = await fetch(endpoint, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'accept': 'application/json, text/event-stream',
+        'mcp-protocol-version': '2025-11-25',
+      },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 2,
+        method: 'tools/list',
+        params: {},
+      }),
+    });
+
+    expect(toolsResponse.status).toBe(200);
+    const toolsBody = await toolsResponse.text();
+    expect(toolsBody).toContain('"tools"');
+  });
 });

--- a/src/services/mcp/mcpHttpServer.test.ts
+++ b/src/services/mcp/mcpHttpServer.test.ts
@@ -1,0 +1,40 @@
+import { AIContextMCPHttpServer } from './mcpHttpServer';
+
+describe('AIContextMCPHttpServer', () => {
+  let server: AIContextMCPHttpServer | null = null;
+
+  afterEach(async () => {
+    if (server) {
+      await server.stop();
+      server = null;
+    }
+  });
+
+  it('starts on an ephemeral port and rejects invalid non-session requests', async () => {
+    server = new AIContextMCPHttpServer({
+      host: '127.0.0.1',
+      port: 0,
+      endpointPath: '/mcp',
+      verbose: false,
+    });
+
+    await server.start();
+    const port = server.getPort();
+
+    expect(port).toBeGreaterThan(0);
+
+    const response = await fetch(`http://127.0.0.1:${port}/mcp`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({}),
+    });
+
+    expect(response.status).toBe(400);
+    const payload = await response.json() as {
+      error?: { message?: string };
+    };
+    expect(payload.error?.message).toContain('No valid session ID provided');
+  });
+});

--- a/src/services/mcp/mcpHttpServer.ts
+++ b/src/services/mcp/mcpHttpServer.ts
@@ -1,0 +1,231 @@
+import { randomUUID } from 'node:crypto';
+import type { AddressInfo, Server as HTTPServer } from 'node:net';
+import { createMcpExpressApp } from '@modelcontextprotocol/sdk/server/express.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js';
+import { AIContextMCPServer, type MCPServerOptions } from './mcpServer';
+
+type JsonRpcError = {
+  jsonrpc: '2.0';
+  error: {
+    code: number;
+    message: string;
+  };
+  id: null;
+};
+
+export interface MCPHttpServerOptions extends MCPServerOptions {
+  host?: string;
+  port?: number;
+  endpointPath?: string;
+}
+
+export class AIContextMCPHttpServer {
+  private options: Required<Pick<MCPHttpServerOptions, 'host' | 'port' | 'endpointPath'>> & MCPServerOptions;
+  private app = createMcpExpressApp();
+  private httpServer: HTTPServer | null = null;
+  private transports = new Map<string, StreamableHTTPServerTransport>();
+  private sessionServers = new Map<string, AIContextMCPServer>();
+
+  constructor(options: MCPHttpServerOptions = {}) {
+    this.options = {
+      host: options.host || '127.0.0.1',
+      port: options.port ?? 3000,
+      endpointPath: this.normalizePath(options.endpointPath || '/mcp'),
+      repoPath: options.repoPath,
+      name: options.name,
+      verbose: options.verbose,
+      contextBuilder: options.contextBuilder,
+    };
+
+    this.app = createMcpExpressApp({ host: this.options.host });
+    this.registerRoutes();
+  }
+
+  async start(): Promise<void> {
+    if (this.httpServer) {
+      return;
+    }
+
+    await new Promise<void>((resolve, reject) => {
+      const server = this.app.listen(this.options.port, this.options.host, () => {
+        this.httpServer = server;
+        resolve();
+      });
+
+      server.on('error', (error: Error) => reject(error));
+    });
+
+    this.log(
+      `MCP Streamable HTTP server listening on http://${this.options.host}:${this.getPort()}${this.options.endpointPath}`
+    );
+  }
+
+  async stop(): Promise<void> {
+    for (const [sessionId, transport] of this.transports.entries()) {
+      try {
+        transport.onclose = undefined;
+        await transport.close();
+      } catch (error) {
+        this.log(`Failed to close transport for session ${sessionId}: ${String(error)}`);
+      }
+    }
+
+    for (const [sessionId, server] of this.sessionServers.entries()) {
+      try {
+        await server.stop();
+      } catch (error) {
+        this.log(`Failed to close MCP server for session ${sessionId}: ${String(error)}`);
+      }
+    }
+
+    this.transports.clear();
+    this.sessionServers.clear();
+
+    if (this.httpServer) {
+      await new Promise<void>((resolve, reject) => {
+        this.httpServer!.close((error) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+          resolve();
+        });
+      });
+      this.httpServer = null;
+    }
+
+    this.log('MCP Streamable HTTP server stopped');
+  }
+
+  getPort(): number {
+    if (!this.httpServer) {
+      return this.options.port;
+    }
+
+    const address = this.httpServer.address();
+    if (!address || typeof address === 'string') {
+      return this.options.port;
+    }
+
+    return (address as AddressInfo).port;
+  }
+
+  private registerRoutes(): void {
+    this.app.all(this.options.endpointPath, async (req: any, res: any) => {
+      try {
+        const sessionId = this.getHeaderValue(req.headers['mcp-session-id']);
+
+        if (sessionId) {
+          const existingTransport = this.transports.get(sessionId);
+          if (!existingTransport) {
+            this.sendJsonRpcError(res, 404, 'Session not found for provided mcp-session-id');
+            return;
+          }
+
+          await existingTransport.handleRequest(req, res, req.body);
+          return;
+        }
+
+        if (req.method === 'POST' && isInitializeRequest(req.body)) {
+          await this.handleInitializeRequest(req, res);
+          return;
+        }
+
+        this.sendJsonRpcError(res, 400, 'Bad Request: No valid session ID provided');
+      } catch (error) {
+        this.log(`Error handling Streamable HTTP request: ${String(error)}`);
+        if (!res.headersSent) {
+          this.sendJsonRpcError(res, 500, 'Internal server error');
+        }
+      }
+    });
+  }
+
+  private async handleInitializeRequest(req: any, res: any): Promise<void> {
+    let sessionServer: AIContextMCPServer | null = null;
+
+    const transport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: () => randomUUID(),
+      onsessioninitialized: (sessionId) => {
+        this.transports.set(sessionId, transport);
+        if (sessionServer) {
+          this.sessionServers.set(sessionId, sessionServer);
+        }
+        this.log(`Session initialized: ${sessionId}`);
+      },
+    });
+
+    transport.onclose = () => {
+      const sessionId = transport.sessionId;
+      if (sessionId) {
+        this.log(`Session closed: ${sessionId}`);
+        void this.cleanupSession(sessionId);
+      }
+    };
+
+    sessionServer = new AIContextMCPServer({
+      repoPath: this.options.repoPath,
+      name: this.options.name,
+      verbose: this.options.verbose,
+      contextBuilder: this.options.contextBuilder,
+    });
+
+    await sessionServer.connectTransport(transport);
+    await transport.handleRequest(req, res, req.body);
+
+    if (!transport.sessionId) {
+      await sessionServer.stop();
+    }
+  }
+
+  private async cleanupSession(sessionId: string): Promise<void> {
+    this.transports.delete(sessionId);
+    const sessionServer = this.sessionServers.get(sessionId);
+    if (sessionServer) {
+      this.sessionServers.delete(sessionId);
+      await sessionServer.stop();
+    }
+  }
+
+  private normalizePath(endpointPath: string): string {
+    if (!endpointPath.startsWith('/')) {
+      return `/${endpointPath}`;
+    }
+    return endpointPath;
+  }
+
+  private getHeaderValue(value: string | string[] | undefined): string | undefined {
+    if (!value) {
+      return undefined;
+    }
+    return Array.isArray(value) ? value[0] : value;
+  }
+
+  private sendJsonRpcError(res: any, statusCode: number, message: string): void {
+    const payload: JsonRpcError = {
+      jsonrpc: '2.0',
+      error: {
+        code: -32000,
+        message,
+      },
+      id: null,
+    };
+
+    res.status(statusCode).json(payload);
+  }
+
+  private log(message: string): void {
+    if (this.options.verbose) {
+      process.stderr.write(`[mcp:http] ${message}\n`);
+    }
+  }
+}
+
+export async function startMCPHttpServer(
+  options: MCPHttpServerOptions = {}
+): Promise<AIContextMCPHttpServer> {
+  const server = new AIContextMCPHttpServer(options);
+  await server.start();
+  return server;
+}

--- a/src/services/mcp/mcpHttpServer.ts
+++ b/src/services/mcp/mcpHttpServer.ts
@@ -18,20 +18,27 @@ export interface MCPHttpServerOptions extends MCPServerOptions {
   host?: string;
   port?: number;
   endpointPath?: string;
+  jsonResponse?: boolean;
+  stateless?: boolean;
 }
 
 export class AIContextMCPHttpServer {
-  private options: Required<Pick<MCPHttpServerOptions, 'host' | 'port' | 'endpointPath'>> & MCPServerOptions;
+  private options: Required<Pick<MCPHttpServerOptions, 'host' | 'port' | 'endpointPath' | 'jsonResponse' | 'stateless'>> & MCPServerOptions;
   private app = createMcpExpressApp();
   private httpServer: HTTPServer | null = null;
   private transports = new Map<string, StreamableHTTPServerTransport>();
   private sessionServers = new Map<string, AIContextMCPServer>();
+  private statelessTransport: StreamableHTTPServerTransport | null = null;
+  private statelessServer: AIContextMCPServer | null = null;
+  private statelessInitPromise: Promise<StreamableHTTPServerTransport> | null = null;
 
   constructor(options: MCPHttpServerOptions = {}) {
     this.options = {
       host: options.host || '127.0.0.1',
       port: options.port ?? 3000,
       endpointPath: this.normalizePath(options.endpointPath || '/mcp'),
+      jsonResponse: options.jsonResponse ?? true,
+      stateless: options.stateless ?? false,
       repoPath: options.repoPath,
       name: options.name,
       verbose: options.verbose,
@@ -39,6 +46,7 @@ export class AIContextMCPHttpServer {
     };
 
     this.app = createMcpExpressApp({ host: this.options.host });
+    this.registerStatusRoute();
     this.registerRoutes();
   }
 
@@ -57,11 +65,32 @@ export class AIContextMCPHttpServer {
     });
 
     this.log(
-      `MCP Streamable HTTP server listening on http://${this.options.host}:${this.getPort()}${this.options.endpointPath}`
+      `MCP Streamable HTTP server listening on http://${this.options.host}:${this.getPort()}${this.options.endpointPath} (mode=${this.options.stateless ? 'stateless' : 'stateful'})`
     );
   }
 
   async stop(): Promise<void> {
+    if (this.statelessTransport) {
+      try {
+        this.statelessTransport.onclose = undefined;
+        await this.statelessTransport.close();
+      } catch (error) {
+        this.log(`Failed to close stateless transport: ${String(error)}`);
+      } finally {
+        this.statelessTransport = null;
+      }
+    }
+
+    if (this.statelessServer) {
+      try {
+        await this.statelessServer.stop();
+      } catch (error) {
+        this.log(`Failed to close stateless MCP server: ${String(error)}`);
+      } finally {
+        this.statelessServer = null;
+      }
+    }
+
     for (const [sessionId, transport] of this.transports.entries()) {
       try {
         transport.onclose = undefined;
@@ -114,6 +143,11 @@ export class AIContextMCPHttpServer {
   private registerRoutes(): void {
     this.app.all(this.options.endpointPath, async (req: any, res: any) => {
       try {
+        if (this.options.stateless) {
+          await this.handleStatelessRequest(req, res);
+          return;
+        }
+
         const sessionId = this.getHeaderValue(req.headers['mcp-session-id']);
 
         if (sessionId) {
@@ -142,11 +176,72 @@ export class AIContextMCPHttpServer {
     });
   }
 
+  private async handleStatelessRequest(req: any, res: any): Promise<void> {
+    const transport = await this.getOrCreateStatelessTransport();
+    await transport.handleRequest(req, res, req.body);
+  }
+
+  private async getOrCreateStatelessTransport(): Promise<StreamableHTTPServerTransport> {
+    if (this.statelessTransport) {
+      return this.statelessTransport;
+    }
+
+    if (this.statelessInitPromise) {
+      return this.statelessInitPromise;
+    }
+
+    this.statelessInitPromise = (async () => {
+      const transport = new StreamableHTTPServerTransport({
+        sessionIdGenerator: undefined,
+        enableJsonResponse: this.options.jsonResponse,
+      });
+
+      transport.onclose = () => {
+        this.log('Stateless transport closed');
+      };
+
+      const server = new AIContextMCPServer({
+        ...(this.options.repoPath ? { repoPath: this.options.repoPath } : {}),
+        ...(this.options.name ? { name: this.options.name } : {}),
+        ...(this.options.verbose !== undefined ? { verbose: this.options.verbose } : {}),
+        ...(this.options.contextBuilder ? { contextBuilder: this.options.contextBuilder } : {}),
+      });
+
+      await server.connectTransport(transport);
+
+      this.statelessTransport = transport;
+      this.statelessServer = server;
+      this.log('Initialized stateless Streamable HTTP transport');
+
+      return transport;
+    })();
+
+    try {
+      return await this.statelessInitPromise;
+    } finally {
+      this.statelessInitPromise = null;
+    }
+  }
+
+  private registerStatusRoute(): void {
+    this.app.get('/', (_req: any, res: any) => {
+      res.status(200).json({
+        service: 'ai-context-mcp-http',
+        status: 'ok',
+        endpoint: this.options.endpointPath,
+        transport: 'streamable-http',
+        jsonResponse: this.options.jsonResponse,
+        mode: this.options.stateless ? 'stateless' : 'stateful',
+      });
+    });
+  }
+
   private async handleInitializeRequest(req: any, res: any): Promise<void> {
     let sessionServer: AIContextMCPServer | null = null;
 
     const transport = new StreamableHTTPServerTransport({
       sessionIdGenerator: () => randomUUID(),
+      enableJsonResponse: this.options.jsonResponse,
       onsessioninitialized: (sessionId) => {
         this.transports.set(sessionId, transport);
         if (sessionServer) {

--- a/src/services/mcp/mcpHttpServer.ts
+++ b/src/services/mcp/mcpHttpServer.ts
@@ -165,10 +165,10 @@ export class AIContextMCPHttpServer {
     };
 
     sessionServer = new AIContextMCPServer({
-      repoPath: this.options.repoPath,
-      name: this.options.name,
-      verbose: this.options.verbose,
-      contextBuilder: this.options.contextBuilder,
+      ...(this.options.repoPath ? { repoPath: this.options.repoPath } : {}),
+      ...(this.options.name ? { name: this.options.name } : {}),
+      ...(this.options.verbose !== undefined ? { verbose: this.options.verbose } : {}),
+      ...(this.options.contextBuilder ? { contextBuilder: this.options.contextBuilder } : {}),
     });
 
     await sessionServer.connectTransport(transport);

--- a/src/services/mcp/mcpServer.ts
+++ b/src/services/mcp/mcpServer.ts
@@ -71,9 +71,10 @@ export class AIContextMCPServer {
 
   constructor(options: MCPServerOptions = {}) {
     this.options = {
-      name: 'ai-context',
-      verbose: false,
-      ...options
+      repoPath: options.repoPath,
+      name: options.name ?? 'ai-context',
+      verbose: options.verbose ?? false,
+      contextBuilder: options.contextBuilder,
     };
 
     this.server = new McpServer({

--- a/src/services/mcp/mcpServer.ts
+++ b/src/services/mcp/mcpServer.ts
@@ -9,6 +9,7 @@
 
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
 import { z } from 'zod';
 import * as path from 'path';
 import * as fs from 'fs-extra';
@@ -64,7 +65,7 @@ export class AIContextMCPServer {
   private server: McpServer;
   private contextBuilder: SemanticContextBuilder;
   private options: MCPServerOptions;
-  private transport: StdioServerTransport | null = null;
+  private transport: Transport | null = null;
   private initialRepoPath: string | null = null;
   private cachedRepoPath: string | null = null;
 
@@ -865,9 +866,18 @@ Actions:
    * Start the MCP server with stdio transport
    */
   async start(): Promise<void> {
-    this.transport = new StdioServerTransport();
-    await this.server.connect(this.transport);
+    const transport = new StdioServerTransport();
+    await this.connectTransport(transport);
     this.log('MCP Server started on stdio');
+  }
+
+  /**
+   * Connect server to a transport instance.
+   * Useful for non-stdio transports (e.g., Streamable HTTP).
+   */
+  async connectTransport(transport: Transport): Promise<void> {
+    this.transport = transport;
+    await this.server.connect(transport);
   }
 
   /**


### PR DESCRIPTION
Adds opt-in Claude Code bootstrap support.

- Generates/merges .mcp.json (project-level MCP config)
- Generates/merges .claude/settings.json with conservative guardrails (PreToolUse + Stop)
- Exports .context/agents to .claude/agents as native subagents
- Does not modify default behavior
- Fully reversible (remove .claude/ and .mcp.json)