### PR TITLE
Replace JSON import with fs.readFileSync for package metadata

### DIFF
--- a/src/version.ts
+++ b/src/version.ts
@@ -2,9 +2,15 @@
  * Centralized version and package constants
  *
  * Single source of truth for version information.
+ * Uses fs.readFileSync to avoid JSON import compatibility issues
+ * across different Node.js versions and module formats.
  */
 
-import pkg from '../package.json';
+import * as fs from 'fs';
+import * as path from 'path';
 
-export const VERSION = pkg.version;
-export const PACKAGE_NAME = pkg.name;
+const packageJsonPath = path.resolve(__dirname, '..', 'package.json');
+const pkg = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
+
+export const VERSION: string = pkg.version;
+export const PACKAGE_NAME: string = pkg.name;


### PR DESCRIPTION
## Summary
Refactored the version module to read `package.json` using `fs.readFileSync` instead of direct JSON import, improving compatibility across different Node.js versions and module formats.

## Key Changes
- Replaced ES6 JSON import with `fs.readFileSync` to read `package.json` at runtime
- Added explicit type annotations (`string`) to exported constants for better type safety
- Updated module to use `path.resolve()` for reliable package.json path resolution
- Added documentation comments explaining the rationale for this approach

## Implementation Details
- The package metadata is now read synchronously from the file system using `fs.readFileSync` with UTF-8 encoding
- The path is resolved relative to the module's directory (`__dirname`) to ensure it works correctly regardless of where the code is executed from
- This approach avoids potential JSON import compatibility issues that can arise with different Node.js versions and module systems (CommonJS vs ESM)

https://claude.ai/code/session_016JUG7pyzNwotZBEvYEct6X