### PR TITLE
[Release] v0.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [v0.9.1]
+## [v0.9.2]
 
 ### Fixed
 
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Running `npx @dotcontext/mcp install` in an interactive terminal now opens the same tool-selection prompt used by the main CLI compatibility command
   - Non-interactive runs without an explicit tool continue to fall back to `all` detected tools
   - The standalone MCP package now prints the post-install restart hint after successful installs, matching the CLI flow
+
+- **Local release bundles are now executable through `npx` from the bundle root**
+  - `build:packages` now generates package-local `node_modules/.bin` shims for bin-bearing bundles
+  - `smoke:packages` now verifies `npm exec` against the generated `cli` and `mcp` bundle roots instead of checking only static manifest fields
 
 ## [0.9.0] - 2026-04-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Local release bundles are now executable through `npx` from the bundle root**
+  - `build:packages` now generates package-local `node_modules/.bin` shims for bin-bearing bundles
+  - `smoke:packages` now verifies `npm exec` against the generated `cli` and `mcp` bundle roots instead of checking only static manifest fields
+
+## [v0.9.1]
+
+### Fixed
+
 - **`@dotcontext/mcp install` now honors the guided install flow**
   - Running `npx @dotcontext/mcp install` in an interactive terminal now opens the same tool-selection prompt used by the main CLI compatibility command
   - Non-interactive runs without an explicit tool continue to fall back to `all` detected tools
   - The standalone MCP package now prints the post-install restart hint after successful installs, matching the CLI flow
-
-- **Local release bundles are now executable through `npx` from the bundle root**
-  - `build:packages` now generates package-local `node_modules/.bin` shims for bin-bearing bundles
-  - `smoke:packages` now verifies `npm exec` against the generated `cli` and `mcp` bundle roots instead of checking only static manifest fields
 
 ## [0.9.0] - 2026-04-11
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dotcontext/cli",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dotcontext/cli",
-      "version": "0.9.1",
+      "version": "0.9.2",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "^7.10.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcontext/cli",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Harness engineering runtime for AI-assisted software delivery, with CLI and MCP surfaces",
   "main": "dist/cli/index.js",
   "exports": {

--- a/scripts/build-package-bundles.js
+++ b/scripts/build-package-bundles.js
@@ -43,6 +43,33 @@ function resetDir(dir) {
   ensureDir(dir);
 }
 
+function writeExecutable(filePath, content) {
+  ensureDir(path.dirname(filePath));
+  fs.writeFileSync(filePath, content, 'utf8');
+  fs.chmodSync(filePath, 0o755);
+}
+
+function createLocalBinShims(pkgRoot, manifest) {
+  if (!manifest.bin) {
+    return;
+  }
+
+  const binDir = path.join(pkgRoot, 'node_modules', '.bin');
+  for (const [binName, target] of Object.entries(manifest.bin)) {
+    const normalizedTarget = target.split('/').join(path.sep);
+    const posixTarget = target.split(path.sep).join('/');
+    const shellShim = `#!/usr/bin/env sh
+set -e
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname "$0")" && pwd)
+exec node "$SCRIPT_DIR/../../${posixTarget}" "$@"
+`;
+    const cmdShim = `@ECHO OFF\r\nnode "%~dp0\\..\\..\\${normalizedTarget}" %*\r\n`;
+
+    writeExecutable(path.join(binDir, binName), shellShim);
+    writeExecutable(path.join(binDir, `${binName}.cmd`), cmdShim);
+  }
+}
+
 function loadTemplate(name) {
   return fs.readFileSync(path.join(repoRoot, 'templates', 'packages', name), 'utf8');
 }
@@ -164,6 +191,7 @@ function buildBundles() {
     }
     fs.writeFileSync(path.join(pkgRoot, 'README.md'), pkg.readme, 'utf8');
     writeJson(path.join(pkgRoot, 'package.json'), pkg.manifest);
+    createLocalBinShims(pkgRoot, pkg.manifest);
   }
 
   console.log(`Prepared package bundles in ${outputRoot}`);

--- a/scripts/smoke-package-bundles.js
+++ b/scripts/smoke-package-bundles.js
@@ -2,6 +2,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const { execFileSync } = require('child_process');
 
 const repoRoot = path.resolve(__dirname, '..');
 const bundlesRoot = path.join(repoRoot, '.release', 'packages');
@@ -62,6 +63,14 @@ function requireFresh(filePath) {
   return require(resolved);
 }
 
+function runBundleCommand(bundleRoot, args) {
+  return execFileSync('npm', ['exec', '--', ...args], {
+    cwd: bundleRoot,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+}
+
 function smokeBundle(bundle) {
   const bundleRoot = path.join(bundlesRoot, bundle.slug);
   const manifestPath = path.join(bundleRoot, 'package.json');
@@ -82,6 +91,10 @@ function smokeBundle(bundle) {
       fs.existsSync(path.join(bundleRoot, manifest.bin[bundle.bin])),
       `${bundle.slug}: bin target missing`
     );
+    assert(
+      fs.existsSync(path.join(bundleRoot, 'node_modules', '.bin', bundle.bin)),
+      `${bundle.slug}: local bin shim missing`
+    );
   }
 
   if (bundle.requiresPrompts) {
@@ -91,6 +104,22 @@ function smokeBundle(bundle) {
   const mod = requireFresh(mainPath);
   for (const exportName of bundle.expectedExports) {
     assert(mod[exportName], `${bundle.slug}: missing export ${exportName}`);
+  }
+
+  if (bundle.slug === 'cli') {
+    const helpOutput = runBundleCommand(bundleRoot, ['@dotcontext/cli', '--help']);
+    assert(helpOutput.includes('dotcontext'), 'cli: local npm exec help failed');
+  }
+
+  if (bundle.slug === 'mcp') {
+    const installOutput = runBundleCommand(bundleRoot, [
+      '@dotcontext/mcp',
+      'install',
+      'codex',
+      '--local',
+      '--dry-run',
+    ]);
+    assert(installOutput.includes('Would install MCP for Codex CLI'), 'mcp: local npm exec install failed');
   }
 
   return {


### PR DESCRIPTION
### Fixed

- **Local release bundles are now executable through `npx` from the bundle root**
  - `build:packages` now generates package-local `node_modules/.bin` shims for bin-bearing bundles
  - `smoke:packages` now verifies `npm exec` against the generated `cli` and `mcp` bundle roots instead of checking only static manifest fields