### PR TITLE
[release] v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0] - 2026-06-27
+
 ### Added
 
 - Added `hook doctor [host] --json` with Codex diagnostics for hook config, TOML hooks feature flags, current dispatch commands, `.context/`, workflow state, recent traces, and trace append failures.
@@ -18,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Included the `integrations` and `pi` bundles in local release preparation so `.release/releases/<version>` matches the five-package build output.
 - Reduced host hook noise: Stop/session-end hooks now emit PREVC workflow guidance only when an active workflow exists.
 - Prevented Stop/session-end hook reentry loops across Claude Code, Codex, and Pi by silently continuing when host reentry flags are active.
 - Kept `hook dispatch` stdout machine-readable by skipping the global update check for hook dispatch commands.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Dotcontext is three things at once:
 
 - a `.context/` convention for durable project knowledge
 - a harness runtime that governs how agents execute work
-- CLI and MCP surfaces that expose the same runtime to humans and AI tools
+- CLI, MCP, and host integration surfaces that expose the same runtime to humans, AI tools, and lifecycle hooks
 
 The repository is organized around one runtime and five package surfaces:
 
@@ -640,11 +640,11 @@ The package build prepares local bundles in `.release/packages/cli`, `.release/p
 
 ## Documentation
 
-📖 **Full documentation site** (bilingual EN / PT-BR), built with Astro + Starlight, lives in [`docs/`](./docs/). Run it locally with `cd docs && npm install && npm run dev`, or build the static site with `npm run build`. It covers installation, a quickstart, all concepts (the `.context` convention, the harness runtime, PREVC, sensors, policies, task contracts, replay), guides, and a full MCP/CLI reference.
+📖 **Full documentation site** (bilingual EN / PT-BR), built with Astro + Starlight, lives in [`docs/`](./docs/). Run it locally with `cd docs && npm install && npm run dev`, or build the static site with `npm run build`. It covers installation, a quickstart, all concepts (the `.context` convention, the harness runtime, PREVC, sensors, policies, task contracts, replay), guides, and full MCP/CLI/hook references.
 
 Other references in this repo:
 
-- [Documentation site](https://dotcontext.dev) — user guide, concepts, and MCP/CLI reference ([`docs/`](./docs/) source)
+- [Documentation site](https://dotcontext.dev) — user guide, concepts, and MCP/CLI/hook reference ([`docs/`](./docs/) source)
 - [Architecture](./ARCHITECTURE.md) - harness architecture and package boundaries
 - [Contributing](./CONTRIBUTING.md) - contributor workflow
 - [Changelog](./CHANGELOG.md) - release-facing changes

--- a/docs/src/content/docs/en/about/contributing.md
+++ b/docs/src/content/docs/en/about/contributing.md
@@ -46,7 +46,7 @@ Here is what each one does and why it matters.
 
 ### `npm run build`
 
-Compiles the TypeScript sources to `dist/` — `dist/cli/`, `dist/harness/`, `dist/mcp/`, and `dist/shared/`, plus their `.d.ts` type definitions. This is the fastest signal: a clean build means types line up and the boundary imports resolve.
+Compiles the TypeScript sources to `dist/` — `dist/cli/`, `dist/harness/`, `dist/mcp/`, `dist/integrations/`, and `dist/shared/`, plus their `.d.ts` type definitions. This is the fastest signal: a clean build means types line up and the boundary imports resolve.
 
 ### `npm test -- --runInBand`
 
@@ -58,9 +58,9 @@ Tests are colocated with the code they cover in `__tests__/` folders, not in a s
 
 ### `npm run build:packages`
 
-Builds the three isolated package bundles into `.release/packages/{cli,harness,mcp}` via `scripts/build-package-bundles.js`. This step is what proves the package boundaries actually hold:
+Builds the five isolated package bundles into `.release/packages/{cli,harness,mcp,integrations,pi}` via `scripts/build-package-bundles.js`. This step is what proves the package boundaries actually hold:
 
-- Copies `dist/` into each package root.
+- Copies `dist/` into compiled package roots and the Pi extension source into the Pi package root.
 - Writes a package-specific `package.json` manifest for each surface — filtered dependencies, `exports`, and `bin` entries.
 - Copies shared files (`LICENSE`, `README.md`).
 - Generates bin shims for the executables (`dotcontext`, `dotcontext-mcp`).
@@ -70,8 +70,8 @@ Builds the three isolated package bundles into `.release/packages/{cli,harness,m
 
 Runs `scripts/smoke-package-bundles.js` to validate the bundles you just built. It is a structural smoke test, not a runtime one, and it checks:
 
-- Each manifest name matches the expected scope (`@dotcontext/cli`, `@dotcontext/harness`, `@dotcontext/mcp`) and the version matches root.
-- The main entry exists (`dist/cli/index.js`, `dist/harness/index.js`, `dist/mcp/index.js`) and so do the `.d.ts` type files.
+- Each manifest name matches the expected scope (`@dotcontext/cli`, `@dotcontext/harness`, `@dotcontext/mcp`, `@dotcontext/integrations`, `@dotcontext/pi`) and the version matches root.
+- The main entry exists for compiled packages (`dist/cli/index.js`, `dist/harness/index.js`, `dist/mcp/index.js`, `dist/integrations/index.js`) and so do the `.d.ts` type files; the Pi extension entry exists under `extension/index.ts`.
 - The expected exports are present in each compiled index.
 - Bin entries and local shims exist for CLI and MCP.
 - **No legacy `dist/services/` folder** ships — this enforces the architecture (domain behavior must not leak into the transport surfaces).
@@ -81,17 +81,19 @@ Runs `scripts/smoke-package-bundles.js` to validate the bundles you just built. 
 The "no `dist/services/`" check is intentional. If a package smoke test fails on it, you have probably moved domain behavior into `cli` or `mcp` instead of `harness`. See [Architecture](/about/architecture/) for the boundary rules.
 :::
 
-## The three packages
+## The five packages
 
-The monorepo publishes three independent packages off one shared version. Understanding which surface owns what keeps your change in the right place.
+The monorepo publishes five independent packages off one shared version. Understanding which surface owns what keeps your change in the right place.
 
 | Package | Role | Bin |
 | --- | --- | --- |
 | `@dotcontext/cli` | Operator-facing sync, import/export, MCP setup, reports, admin workflows. | `dotcontext` |
 | `@dotcontext/harness` | Reusable runtime: domain rules, sessions, policies, sensors, contracts, replay, workflow state. | — |
 | `@dotcontext/mcp` | Model Context Protocol transport adapter and installer for AI tools. | `dotcontext-mcp` |
+| `@dotcontext/integrations` | Host hook adapters and event mappers for Claude Code, Codex CLI, and Pi. | — |
+| `@dotcontext/pi` | Pi npm extension for in-process lifecycle hooks. | — |
 
-All three are versioned together so they stay compatible. For the full export and packaging detail, see [Packaging & versioning](/reference/configuration/).
+All five are versioned together so they stay compatible. For the full export and packaging detail, see [Packaging & versioning](/reference/configuration/).
 
 :::note
 The root `package.json` only exposes the `dotcontext` bin. The `dotcontext-mcp` binary appears in the `.release/packages/mcp/` manifest produced by `build:packages` — the root CLI starts the server with `dotcontext mcp`, not a separate binary.
@@ -144,6 +146,6 @@ Open your pull request against `main` on [GitHub](https://github.com/vinilana/do
 ## Next steps
 
 - [Architecture](/about/architecture/) — the boundaries your change must respect.
-- [Packaging & versioning](/reference/configuration/) — how the three packages are built and released.
+- [Packaging & versioning](/reference/configuration/) — how the five packages are built and released.
 - [CLI commands](/reference/cli-commands/) — the operator surface you may be extending.
 - [MCP tools](/reference/mcp-tools/) — the tool actions exposed to AI clients.

--- a/docs/src/content/docs/en/getting-started/introduction.md
+++ b/docs/src/content/docs/en/getting-started/introduction.md
@@ -1,6 +1,6 @@
 ---
 title: Introduction
-description: What dotcontext is, the problem it solves, and how its cli, harness, and mcp surfaces fit together.
+description: What dotcontext is, the problem it solves, and how its cli, harness, mcp, and integration surfaces fit together.
 sidebar:
   order: 1
 ---
@@ -30,27 +30,32 @@ dotcontext turns that scattered, throwaway context into a single source of truth
 
 ## The shape: cli -> harness <- mcp
 
-dotcontext is built around one core runtime — the **harness** — with two surfaces wrapped around it:
+dotcontext is built around one core runtime — the **harness** — with operator, protocol, and host-integration surfaces wrapped around it:
 
 ```text
 cli -> harness <- mcp
+       ^
+       integrations
 ```
 
-The harness holds all the real behavior. The CLI and MCP are thin boundaries that operators and AI tools use to reach it.
+The harness holds all the real behavior. The CLI, MCP, and host integrations are thin boundaries that operators, AI tools, and lifecycle hooks use to reach it.
 
 | Surface | Package | Who uses it | What it does |
 | --- | --- | --- | --- |
-| **harness** | `@dotcontext/harness` | imported by the other two | The reusable runtime: PREVC workflow state, sessions, sensors, policies, task contracts, replay, and datasets. |
+| **harness** | `@dotcontext/harness` | imported by the other surfaces | The reusable runtime: PREVC workflow state, sessions, sensors, policies, task contracts, replay, and datasets. |
 | **cli** | `@dotcontext/cli` | operators (you, in a terminal) | Sync and admin: export/import rules, agents, and skills between `.context/` and AI tool directories, install the MCP server, run reports, and manage workflow state. |
 | **mcp** | `@dotcontext/mcp` | AI tools (Claude Code, Cursor, etc.) | The Model Context Protocol transport: exposes harness behavior as MCP tools and resources, plus an installer for supported clients. |
+| **integrations** | `@dotcontext/integrations`, `@dotcontext/pi` | host hooks and extensions | Lifecycle adapters for Claude Code, Codex CLI, and Pi that bootstrap context, trace work, and render workflow reminders. |
 
-### The three package surfaces
+### The five package surfaces
 
-dotcontext ships as three independently publishable npm packages that share one version:
+dotcontext ships as five independently publishable npm packages that share one version:
 
 - **`@dotcontext/harness`** — the reusable runtime. Domain rules, workflow routing, session and runtime state, sensors, policies, and contracts. Import it if you are building on top of dotcontext.
 - **`@dotcontext/cli`** — the operator-facing command line. This is the `dotcontext` binary you run to sync artifacts and configure tools.
 - **`@dotcontext/mcp`** — the MCP transport adapter and installer. This is what your AI tools connect to.
+- **`@dotcontext/integrations`** — host hook adapters and event mappers for Claude Code, Codex CLI, and Pi.
+- **`@dotcontext/pi`** — the Pi npm extension for in-process lifecycle hooks.
 
 :::note
 The standalone CLI is **sync and admin focused**. Context creation, AI-generated fills, and plan scaffolding are **MCP-first** — they run through the MCP server and Claude-powered tools, not as direct CLI commands.

--- a/docs/src/content/docs/en/index.mdx
+++ b/docs/src/content/docs/en/index.mdx
@@ -1,9 +1,9 @@
 ---
 title: dotcontext
-description: dotcontext is a harness for your harness — the contextual layer that keeps your work going no matter which AI tool you use, with shared context, PREVC workflow, sensors, policies, task contracts, replay, and MCP/CLI surfaces.
+description: dotcontext is a harness for your harness — the contextual layer that keeps your work going no matter which AI tool you use, with shared context, PREVC workflow, sensors, policies, task contracts, replay, and MCP/CLI/hook surfaces.
 template: splash
 hero:
-  tagline: A harness for your harness — the contextual layer that keeps your work going no matter which AI tool you switch to. Shared context, workflow, policies, sensors, contracts, and replayable history, across MCP and CLI.
+  tagline: A harness for your harness — the contextual layer that keeps your work going no matter which AI tool you switch to. Shared context, workflow, policies, sensors, contracts, and replayable history, across MCP, CLI, and hooks.
   image:
     file: ../../../assets/logo.svg
   actions:
@@ -26,10 +26,12 @@ import { Card, CardGrid, LinkCard } from '@astrojs/starlight/components';
 
 **dotcontext is a harness for your harness.** We provide the necessary contextual layer to keep the work going no matter which AI tool you switch to — shared project context, workflow structure, policies, sensors, task contracts, replayable execution history, and MCP access, all in one system. The goal is not only to give a model more context — it's to make agent execution **legible, constrained, reusable, and auditable**.
 
-The repository is organized around one runtime and three package surfaces:
+The repository is organized around one runtime with CLI, MCP, and host-integration surfaces:
 
 ```text
 cli -> harness <- mcp
+       ^
+       integrations
 ```
 
 <CardGrid stagger>

--- a/docs/src/content/docs/pt-br/about/architecture.md
+++ b/docs/src/content/docs/pt-br/about/architecture.md
@@ -155,12 +155,12 @@ import { HarnessExecutionService } from '@dotcontext/harness';
 import { AIContextMCPServer } from '@dotcontext/mcp';
 ```
 
-Como os três compartilham a mesma versão raiz, fixar um e casar os demais mantém as superfícies compatíveis.
+Como os cinco compartilham a mesma versão raiz, fixar um e casar os demais mantém as superfícies compatíveis.
 
 ## Como tudo se encaixa
 
 1. Um **operador** roda a CLI, ou um **cliente de IA** chama uma tool do MCP.
-2. O transporte (`cli` ou `mcp`) traduz a requisição em uma chamada ao **harness**.
+2. O transporte (`cli`, `mcp` ou `integrations`) traduz a requisição em uma chamada ao **harness**.
 3. O harness executa o trabalho através de seus **serviços de application** e **regras de domain**.
 4. O estado é persistido pelos **adapters** em `.context/`.
 5. Qualquer outro transporte que leia esse estado — agora ou depois — vê o mesmo registro durável.

--- a/docs/src/content/docs/pt-br/about/contributing.md
+++ b/docs/src/content/docs/pt-br/about/contributing.md
@@ -46,7 +46,7 @@ Veja o que cada um faz e por que importa.
 
 ### `npm run build`
 
-Compila os fontes TypeScript para `dist/` — `dist/cli/`, `dist/harness/`, `dist/mcp/` e `dist/shared/`, além das definições de tipo `.d.ts`. É o sinal mais rápido: um build limpo significa que os tipos batem e os imports entre fronteiras resolvem.
+Compila os fontes TypeScript para `dist/` — `dist/cli/`, `dist/harness/`, `dist/mcp/`, `dist/integrations/` e `dist/shared/`, além das definições de tipo `.d.ts`. É o sinal mais rápido: um build limpo significa que os tipos batem e os imports entre fronteiras resolvem.
 
 ### `npm test -- --runInBand`
 
@@ -58,9 +58,9 @@ Os testes ficam colocados junto do código que cobrem, em pastas `__tests__/`, e
 
 ### `npm run build:packages`
 
-Faz o build dos três bundles de pacote isolados em `.release/packages/{cli,harness,mcp}` via `scripts/build-package-bundles.js`. Esta etapa é o que prova que as fronteiras dos pacotes realmente se sustentam:
+Faz o build dos cinco bundles de pacote isolados em `.release/packages/{cli,harness,mcp,integrations,pi}` via `scripts/build-package-bundles.js`. Esta etapa é o que prova que as fronteiras dos pacotes realmente se sustentam:
 
-- Copia o `dist/` para a raiz de cada pacote.
+- Copia o `dist/` para as raízes dos pacotes compilados e o source da extensão Pi para a raiz do pacote Pi.
 - Escreve um manifesto `package.json` específico para cada surface — dependências filtradas, `exports` e entradas `bin`.
 - Copia arquivos compartilhados (`LICENSE`, `README.md`).
 - Gera os shims de bin para os executáveis (`dotcontext`, `dotcontext-mcp`).
@@ -70,8 +70,8 @@ Faz o build dos três bundles de pacote isolados em `.release/packages/{cli,harn
 
 Roda `scripts/smoke-package-bundles.js` para validar os bundles que você acabou de gerar. É um smoke test estrutural, não de runtime, e verifica:
 
-- Que o nome de cada manifesto bate com o escopo esperado (`@dotcontext/cli`, `@dotcontext/harness`, `@dotcontext/mcp`) e que a versão bate com a raiz.
-- Que o entry principal existe (`dist/cli/index.js`, `dist/harness/index.js`, `dist/mcp/index.js`) e que os arquivos de tipo `.d.ts` também existem.
+- Que o nome de cada manifesto bate com o escopo esperado (`@dotcontext/cli`, `@dotcontext/harness`, `@dotcontext/mcp`, `@dotcontext/integrations`, `@dotcontext/pi`) e que a versão bate com a raiz.
+- Que o entry principal existe para os pacotes compilados (`dist/cli/index.js`, `dist/harness/index.js`, `dist/mcp/index.js`, `dist/integrations/index.js`) e que os arquivos de tipo `.d.ts` também existem; o entry da extensão Pi existe em `extension/index.ts`.
 - Que os `exports` esperados estão presentes em cada index compilado.
 - Que as entradas `bin` e os shims locais existem para CLI e MCP.
 - Que **nenhuma pasta legada `dist/services/`** é publicada — isso reforça a arquitetura (comportamento de domínio não pode vazar para as surfaces de transporte).
@@ -81,17 +81,19 @@ Roda `scripts/smoke-package-bundles.js` para validar os bundles que você acabou
 A verificação de "nenhum `dist/services/`" é intencional. Se um smoke test de pacote falhar nela, provavelmente você moveu comportamento de domínio para `cli` ou `mcp` em vez de para o `harness`. Veja a [Arquitetura](/pt-br/about/architecture/) para as regras de fronteira.
 :::
 
-## Os três pacotes
+## Os cinco pacotes
 
-O monorepo publica três pacotes independentes a partir de uma única versão compartilhada. Entender qual surface é dona de quê mantém sua mudança no lugar certo.
+O monorepo publica cinco pacotes independentes a partir de uma única versão compartilhada. Entender qual surface é dona de quê mantém sua mudança no lugar certo.
 
 | Pacote | Papel | Bin |
 | --- | --- | --- |
 | `@dotcontext/cli` | Sync, import/export, setup de MCP, relatórios e workflows admin voltados ao operador. | `dotcontext` |
 | `@dotcontext/harness` | Runtime reutilizável: regras de domínio, sessions, policies, sensors, contracts, replay, estado de workflow. | — |
 | `@dotcontext/mcp` | Adaptador de transporte do Model Context Protocol e instalador para ferramentas de IA. | `dotcontext-mcp` |
+| `@dotcontext/integrations` | Adaptadores de hooks de host e mappers de eventos para Claude Code, Codex CLI e Pi. | — |
+| `@dotcontext/pi` | Extensão npm do Pi para hooks in-process. | — |
 
-Os três são versionados juntos para permanecerem compatíveis. Para o detalhe completo de exports e packaging, veja [Packaging & versionamento](/pt-br/reference/configuration/).
+Os cinco são versionados juntos para permanecerem compatíveis. Para o detalhe completo de exports e packaging, veja [Packaging & versionamento](/pt-br/reference/configuration/).
 
 :::note
 O `package.json` da raiz expõe apenas o bin `dotcontext`. O binário `dotcontext-mcp` aparece no manifesto `.release/packages/mcp/` produzido pelo `build:packages` — a CLI raiz inicia o servidor com `dotcontext mcp`, e não com um binário separado.
@@ -144,6 +146,6 @@ Abra seu pull request contra a `main` no [GitHub](https://github.com/vinilana/do
 ## Próximos passos
 
 - [Arquitetura](/pt-br/about/architecture/) — as fronteiras que sua mudança precisa respeitar.
-- [Packaging & versionamento](/pt-br/reference/configuration/) — como os três pacotes são construídos e publicados.
+- [Packaging & versionamento](/pt-br/reference/configuration/) — como os cinco pacotes são construídos e publicados.
 - [Comandos da CLI](/pt-br/reference/cli-commands/) — a surface de operador que você pode estar estendendo.
 - [Tools MCP](/pt-br/reference/mcp-tools/) — as actions de tool expostas aos clientes de IA.

--- a/docs/src/content/docs/pt-br/getting-started/introduction.md
+++ b/docs/src/content/docs/pt-br/getting-started/introduction.md
@@ -1,6 +1,6 @@
 ---
 title: Introdução
-description: O que é o dotcontext, o problema que ele resolve e como as superfícies cli, harness e mcp se encaixam.
+description: O que é o dotcontext, o problema que ele resolve e como as superfícies cli, harness, mcp e integrações se encaixam.
 sidebar:
   order: 1
 ---
@@ -30,27 +30,32 @@ O dotcontext transforma esse contexto espalhado e descartável em uma única fon
 
 ## A forma: cli -> harness <- mcp
 
-O dotcontext é construído em torno de um runtime central — o **harness** — com duas superfícies envolvendo-o:
+O dotcontext é construído em torno de um runtime central — o **harness** — com superfícies de operador, protocolo e integrações de host envolvendo-o:
 
 ```text
 cli -> harness <- mcp
+       ^
+       integrations
 ```
 
-O harness contém todo o comportamento real. A CLI e o MCP são fronteiras finas que operadores e ferramentas de IA usam para alcançá-lo.
+O harness contém todo o comportamento real. A CLI, o MCP e as integrações de host são fronteiras finas que operadores, ferramentas de IA e hooks de ciclo de vida usam para alcançá-lo.
 
 | Superfície | Pacote | Quem usa | O que faz |
 | --- | --- | --- | --- |
-| **harness** | `@dotcontext/harness` | importado pelas outras duas | O runtime reutilizável: estado do workflow PREVC, sessions, sensors, policies, task contracts, replay e datasets. |
+| **harness** | `@dotcontext/harness` | importado pelas outras superfícies | O runtime reutilizável: estado do workflow PREVC, sessions, sensors, policies, task contracts, replay e datasets. |
 | **cli** | `@dotcontext/cli` | operadores (você, no terminal) | Sync e admin: exportar/importar rules, agents e skills entre `.context/` e os diretórios das ferramentas de IA, instalar o servidor MCP, rodar reports e gerenciar o estado do workflow. |
 | **mcp** | `@dotcontext/mcp` | ferramentas de IA (Claude Code, Cursor, etc.) | O transporte Model Context Protocol: expõe o comportamento do harness como tools e resources MCP, além de um instalador para clients suportados. |
+| **integrations** | `@dotcontext/integrations`, `@dotcontext/pi` | hooks e extensões de host | Adapters de ciclo de vida para Claude Code, Codex CLI e Pi que fazem bootstrap de contexto, registram traces e renderizam lembretes de workflow. |
 
-### As três superfícies de pacote
+### As cinco superfícies de pacote
 
-O dotcontext é distribuído como três pacotes npm publicáveis de forma independente que compartilham uma única versão:
+O dotcontext é distribuído como cinco pacotes npm publicáveis de forma independente que compartilham uma única versão:
 
 - **`@dotcontext/harness`** — o runtime reutilizável. Regras de domínio, roteamento do workflow, estado de session e runtime, sensors, policies e contracts. Importe-o se você está construindo em cima do dotcontext.
 - **`@dotcontext/cli`** — a linha de comando voltada ao operador. É o binário `dotcontext` que você roda para sincronizar artefatos e configurar ferramentas.
 - **`@dotcontext/mcp`** — o adaptador de transporte MCP e o instalador. É a isso que suas ferramentas de IA se conectam.
+- **`@dotcontext/integrations`** — adapters de hooks de host e mappers de eventos para Claude Code, Codex CLI e Pi.
+- **`@dotcontext/pi`** — a extensão npm do Pi para hooks in-process.
 
 :::note
 A CLI standalone é **focada em sync e admin**. Criação de contexto, fills gerados por IA e scaffolding de plano são **MCP-first** — rodam através do servidor MCP e das tools com Claude, não como comandos diretos da CLI.

--- a/docs/src/content/docs/pt-br/index.mdx
+++ b/docs/src/content/docs/pt-br/index.mdx
@@ -1,9 +1,9 @@
 ---
 title: dotcontext
-description: o dotcontext é um harness para o seu harness — a camada de contexto que mantém seu trabalho fluindo independente da ferramenta de IA que você usa, com contexto compartilhado, workflow PREVC, sensores, políticas, contratos de tarefa, replay e superfícies MCP/CLI.
+description: o dotcontext é um harness para o seu harness — a camada de contexto que mantém seu trabalho fluindo independente da ferramenta de IA que você usa, com contexto compartilhado, workflow PREVC, sensores, políticas, contratos de tarefa, replay e superfícies MCP/CLI/hooks.
 template: splash
 hero:
-  tagline: Um harness para o seu harness — a camada de contexto que mantém seu trabalho fluindo, não importa para qual ferramenta de IA você troque. Contexto compartilhado, workflow, políticas, sensores, contratos e histórico reproduzível, via MCP e CLI.
+  tagline: Um harness para o seu harness — a camada de contexto que mantém seu trabalho fluindo, não importa para qual ferramenta de IA você troque. Contexto compartilhado, workflow, políticas, sensores, contratos e histórico reproduzível, via MCP, CLI e hooks.
   image:
     file: ../../../assets/logo.svg
   actions:
@@ -26,10 +26,12 @@ import { Card, CardGrid, LinkCard } from '@astrojs/starlight/components';
 
 O **dotcontext é um harness para o seu harness.** Fornecemos a camada de contexto necessária para manter o trabalho fluindo, não importa para qual ferramenta de IA você troque — contexto de projeto compartilhado, estrutura de workflow, políticas, sensores, contratos de tarefa, histórico de execução reproduzível e acesso via MCP, tudo em um único sistema. O objetivo não é só dar mais contexto ao modelo — é tornar a execução do agente **legível, restrita, reutilizável e auditável**.
 
-O repositório se organiza em torno de um runtime e três superfícies de pacote:
+O repositório se organiza em torno de um runtime com superfícies CLI, MCP e integrações de host:
 
 ```text
 cli -> harness <- mcp
+       ^
+       integrations
 ```
 
 <CardGrid stagger>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dotcontext/cli",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dotcontext/cli",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dotcontext/cli",
-  "version": "1.0.0",
-  "description": "A harness for your harness — the contextual layer that keeps work going across any AI tool, with CLI and MCP surfaces",
+  "version": "1.1.0",
+  "description": "A harness for your harness — the contextual layer that keeps work going across any AI tool, with CLI, MCP, and host integration surfaces",
   "main": "dist/cli/index.js",
   "exports": {
     ".": "./dist/cli/index.js",

--- a/scripts/release-packages.js
+++ b/scripts/release-packages.js
@@ -11,6 +11,7 @@ const bundlesRoot = path.join(releaseRoot, 'packages');
 const releasesRoot = path.join(releaseRoot, 'releases');
 const rootPackagePath = path.join(repoRoot, 'package.json');
 const rootPackage = JSON.parse(fs.readFileSync(rootPackagePath, 'utf8'));
+const releasePackageSlugs = ['cli', 'harness', 'mcp', 'integrations', 'pi'];
 
 function run(command, args) {
   execFileSync(command, args, {
@@ -66,7 +67,7 @@ function buildRelease(version) {
   fs.rmSync(releaseDir, { recursive: true, force: true });
   fs.mkdirSync(releaseDir, { recursive: true });
 
-  for (const slug of ['cli', 'harness', 'mcp']) {
+  for (const slug of releasePackageSlugs) {
     const sourceDir = path.join(bundlesRoot, slug);
     const targetDir = path.join(releaseDir, slug);
     assert(fs.existsSync(sourceDir), `Missing bundle: ${slug}`);
@@ -78,7 +79,7 @@ function buildRelease(version) {
     version,
     rootVersion: rootPackage.version,
     createdAt: new Date().toISOString(),
-    packages: ['cli', 'harness', 'mcp'].map((slug) => ({
+    packages: releasePackageSlugs.map((slug) => ({
       slug,
       path: `./${slug}`,
     })),


### PR DESCRIPTION
## [1.1.0] - 2026-06-27

### Added

- Added `hook doctor [host] --json` with Codex diagnostics for hook config, TOML hooks feature flags, current dispatch commands, `.context/`, workflow state, recent traces, and trace append failures.
- Added hook readiness summaries for `SessionStart`, including missing/partial/ready tiers, capped setup gaps, workflow-missing reminder cooldown, and active PREVC preflight.
- Added lightweight Bash trace classification for hook traces (`test`, `build`, `lint`, `inspection`, migration/destructive hints) without running extra commands.
- Added the `mcp:install` recommended hooks flow, including `--with-hooks`, `--no-hooks`, Codex `--hook-format`, `/hooks` trust, non-blocking hook behavior, and Pi's no-duplicate MCP snippet behavior in combined installs.
- Added an interactive **Integrations** submenu with Install/Uninstall MCP, Install/Uninstall Hooks, Install/Uninstall Pi Extension, and Back, wired to `mcp:install`, `mcp:uninstall`, and the hook install/uninstall service paths.
- Added `mcp:uninstall [tool]` with global/local scope, dry-run previews, and safe removal of only dotcontext MCP entries.

### Fixed

- Included the `integrations` and `pi` bundles in local release preparation so `.release/releases/<version>` matches the five-package build output.
- Reduced host hook noise: Stop/session-end hooks now emit PREVC workflow guidance only when an active workflow exists.
- Prevented Stop/session-end hook reentry loops across Claude Code, Codex, and Pi by silently continuing when host reentry flags are active.
- Kept `hook dispatch` stdout machine-readable by skipping the global update check for hook dispatch commands.
- Prevented `SessionStart` hooks from creating `.context/runtime` before context initialization has been confirmed.
- Made hook tracing more resilient by recovering stale hook session bindings, treating trace append failures as non-blocking, and recording repeated failures under `.context/runtime/hooks/trace-failures.json`.
- Kept hook trace-failure diagnostics in the harness runtime state instead of duplicating a second store in host integrations.
- Aligned hook readiness fallback checks with `context check` so hook-only runtime files do not count as harness runtime readiness.
- Made `hook doctor` inspect only the tail of large trace files when looking for the latest trace timestamp.
- Suppressed inactive, skipped, blank, or malformed workflow-guide output in Claude Code, Codex, and Pi hook renderers.
- Made Stop hooks silently continue when workflow state is missing or malformed instead of returning non-zero hook failures.
- Aligned Pi session-start context summaries with Claude/Codex by recognizing `workflow` and `harness` readiness flags.

### Changed

- Defaulted hook install/uninstall to project-level config; pass `--global` to target home-directory hook config.
- Replaced the interactive prompt runtime with `@clack/prompts` and removed direct Inquirer runtime dependencies.
- Raised the supported Node.js engine requirement to `>=20.12.0`.
- Renamed the interactive menu labels from Quick Sync to **Synchronize my context** and Reverse Sync to **Import my context**.
- Aligned Pi extension uninstall guidance on `pi uninstall @dotcontext/pi` across CLI output and docs.
- Anchored the Claude Code `PostToolUse` matcher to exact `Write`, `Edit`, and `Bash` events.
- Tightened Codex TOML hook install detection so partially installed hook blocks are repaired instead of being treated as up to date.
- Hook dispatch now resolves repo roots as `--repo-path`, nearest ancestor with `.context/`, `cwd`, then `process.cwd()`.
- Standardized hook runtime hints in English across Claude Code, Codex, and Pi outputs.
- Updated hook documentation to clarify that session-end PREVC reminders appear only for active workflows.
- Documented Codex `/hooks` trust as a required post-install step and expanded hook renderer tests across Claude Code, Codex, and Pi.