### PR TITLE
[fix] Harden hook output contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Removed the Codex-only `source` field from hook stdout so `SessionStart` output matches Codex's strict JSON schema.
+- Added host-specific hook stdout contracts so future integrations default to strict, schema-safe output instead of inheriting fields from other hosts.
+- Made hook trace appends recover from corrupt harness session bindings and write session metadata atomically to avoid transient invalid JSON.
+
 ## [1.1.0] - 2026-06-27
 
 ### Added

--- a/src/cli/services/__tests__/hookDispatchService.test.ts
+++ b/src/cli/services/__tests__/hookDispatchService.test.ts
@@ -150,12 +150,16 @@ describe('HookDispatchService session lifecycle', () => {
 
       expect(startResult.exitCode).toBe(0);
       expect(startResult.output).toMatchObject({
-        source,
         hookSpecificOutput: {
           hookEventName: 'SessionStart',
           additionalContext: expect.stringContaining('this repository does not have .context/ yet'),
         },
       });
+      if (source === 'claude-code') {
+        expect(startResult.output).toMatchObject({ source });
+      } else {
+        expect(startResult.output).not.toHaveProperty('source');
+      }
       expect(JSON.stringify(startResult.output)).toContain('context init');
       expect(await fs.pathExists(path.join(tempDir, '.context'))).toBe(false);
       expect(await fs.pathExists(path.join(tempDir, '.context', 'runtime', 'logs'))).toBe(false);
@@ -286,6 +290,71 @@ describe('HookDispatchService session lifecycle', () => {
     expect(traceContent).toContain('tool.use');
   });
 
+  it('recreates corrupt PostToolUse session bindings and appends trace to the recovered session', async () => {
+    const sessionId = 'host-session-corrupt';
+    const corruptHarnessSessionId = 'corrupt-harness-session';
+    await fs.outputFile(
+      path.join(tempDir, '.context', 'runtime', 'sessions', corruptHarnessSessionId, 'session.json'),
+      '{'
+    );
+    await saveHookHarnessSession({
+      harnessSessionId: corruptHarnessSessionId,
+      hostSessionId: sessionId,
+      source: 'codex',
+      repoPath: tempDir,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+
+    const postStdin = PassThrough.from([
+      JSON.stringify({
+        session_id: sessionId,
+        cwd: tempDir,
+        hook_event_name: 'PostToolUse',
+        tool_name: 'Write',
+        tool_input: { file_path: 'README.md' },
+      }),
+    ]);
+    const postStdout = new PassThrough();
+    postStdout.on('data', () => {});
+
+    const postResult = await runHookDispatch({
+      source: 'codex',
+      repoPath: tempDir,
+      stdin: postStdin,
+      stdout: postStdout,
+    });
+
+    expect(postResult.exitCode).toBe(0);
+    expect(postResult.output).toEqual({ continue: true });
+
+    const recreatedSessionId = await getHookHarnessSessionId({
+      repoPath: tempDir,
+      source: 'codex',
+      hostSessionId: sessionId,
+    });
+    expect(recreatedSessionId).toBeDefined();
+    expect(recreatedSessionId).not.toBe(corruptHarnessSessionId);
+
+    const tracePath = path.join(
+      tempDir,
+      '.context',
+      'runtime',
+      'sessions',
+      recreatedSessionId!,
+      'trace.jsonl'
+    );
+    const traceContent = await fs.readFile(tracePath, 'utf8');
+    expect(traceContent).toContain('tool.use');
+    expect(await fs.pathExists(path.join(
+      tempDir,
+      '.context',
+      'runtime',
+      'hooks',
+      'trace-failures.json'
+    ))).toBe(false);
+  });
+
   it('records trace append failures without blocking PostToolUse', async () => {
     const sessionId = 'host-session-trace-failure';
     await saveHookHarnessSession({
@@ -357,11 +426,11 @@ describe('HookDispatchService session lifecycle', () => {
 
     expect(startResult.exitCode).toBe(0);
     expect(startResult.output).toMatchObject({
-      source: 'codex',
       hookSpecificOutput: {
         hookEventName: 'SessionStart',
       },
     });
+    expect(startResult.output).not.toHaveProperty('source');
   });
 
   it('emits workflow missing reminder only once per cooldown on SessionStart', async () => {
@@ -546,12 +615,12 @@ describe('HookDispatchService session lifecycle', () => {
 
     expect(stopResult.exitCode).toBe(0);
     expect(stopResult.output).toMatchObject({
-      source: 'codex',
       hookSpecificOutput: {
         hookEventName: 'Stop',
         additionalContext: expect.stringContaining('feature-x'),
       },
     });
+    expect(stopResult.output).not.toHaveProperty('source');
   });
 
   it.each(['Stop', 'SubagentStop'])(

--- a/src/cli/services/hookDispatchService.ts
+++ b/src/cli/services/hookDispatchService.ts
@@ -18,6 +18,7 @@ import type { CodexHookInput } from '../../integrations/codex/hooks/mapCodexEven
 import {
   ensureHookHarnessSession,
   extractHarnessSessionId,
+  finalizeHostHookOutput,
   getHookHarnessSessionId,
   isSessionEndReentry,
   normalizeToolEvent,
@@ -190,7 +191,7 @@ function isAppendTraceRequest(mapped: { tool: string; params: unknown }): boolea
     && mapped.params.action === 'appendTrace';
 }
 
-function isMissingHarnessSessionResponse(
+function isRecoverableHarnessSessionResponse(
   response: HarnessHookResponse,
   harnessSessionId?: string
 ): boolean {
@@ -199,11 +200,25 @@ function isMissingHarnessSessionResponse(
   }
 
   const message = response.error.message;
-  if (!message.includes('Harness session not found')) {
+  if (message.includes('Harness session not found')) {
+    return !harnessSessionId || message.includes(harnessSessionId);
+  }
+
+  if (!harnessSessionId) {
     return false;
   }
 
-  return !harnessSessionId || message.includes(harnessSessionId);
+  const normalizedMessage = message.replace(/\\/g, '/');
+  const sessionPathFragment = `/sessions/${harnessSessionId}/session.json`;
+  const looksLikeJsonParseFailure = normalizedMessage.includes('Unexpected end of JSON input')
+    || normalizedMessage.includes('Unexpected token')
+    || normalizedMessage.includes('Expected property name')
+    || normalizedMessage.includes('Expected double-quoted property name')
+    || normalizedMessage.includes('Expected \',\' or \'}\'')
+    || normalizedMessage.includes('not valid JSON');
+
+  return looksLikeJsonParseFailure
+    && (!normalizedMessage.includes('/sessions/') || normalizedMessage.includes(sessionPathFragment));
 }
 
 async function recreateHookHarnessSession(
@@ -387,7 +402,7 @@ async function dispatchShellHookEvent(
     if (
       isAppendTraceRequest(mapped)
       && normalizedEvent.sessionId
-      && isMissingHarnessSessionResponse(response, harnessSessionId)
+      && isRecoverableHarnessSessionResponse(response, harnessSessionId)
     ) {
       try {
         const recreatedSessionId = await recreateHookHarnessSession(adapter, {
@@ -527,6 +542,7 @@ export async function runHookDispatch(
   }
 
   const exitCode = resolveExitCode(response);
+  output = finalizeHostHookOutput(options.source, output);
 
   stdout.write(`${JSON.stringify(output)}\n`);
 

--- a/src/harness/adapters/out/runtimeState/runtimeStateService.ts
+++ b/src/harness/adapters/out/runtimeState/runtimeStateService.ts
@@ -172,7 +172,14 @@ export class HarnessRuntimeStateService {
 
   private async saveSession(session: HarnessSessionRecord): Promise<void> {
     await this.ensureSessionDir(session.id);
-    await fs.writeJson(this.sessionFile(session.id), session, { spaces: 2 });
+    const sessionFile = this.sessionFile(session.id);
+    const tmpFile = `${sessionFile}.${process.pid}.${randomUUID()}.tmp`;
+    try {
+      await fs.writeJson(tmpFile, session, { spaces: 2 });
+      await fs.rename(tmpFile, sessionFile);
+    } finally {
+      await fs.remove(tmpFile).catch(() => undefined);
+    }
   }
 
   private async appendTraceLine(sessionId: string, trace: HarnessTraceRecord): Promise<void> {

--- a/src/integrations/__tests__/hookRoundTrip.test.ts
+++ b/src/integrations/__tests__/hookRoundTrip.test.ts
@@ -2,11 +2,13 @@ import {
   createClaudeCodeHookAdapter,
   createCodexHookAdapter,
   createPiDevHookAdapter,
+  finalizeHostHookOutput,
   mapClaudeCodeEvent,
   mapClaudeCodeResponse,
   mapCodexEvent,
   mapCodexResponse,
   mapHostHookResponse,
+  mapHostHookResponseForSource,
   mapPiEvent,
   mapPiResponse,
   normalizeToolEvent,
@@ -208,7 +210,8 @@ describe('hook mapper unit tests', () => {
         },
       });
 
-      expect(output.source).toBe('codex');
+      expect(output).not.toHaveProperty('source');
+      expect(Object.keys(output)).toEqual(['hookSpecificOutput']);
       expect(output.hookSpecificOutput).toEqual({
         hookEventName: 'SessionStart',
         additionalContext: expect.stringContaining('scaffold ready (docs, workflow, harness)'),
@@ -233,7 +236,6 @@ describe('hook mapper unit tests', () => {
       );
 
       expect(output).toEqual({
-        source: 'codex',
         continue: true,
       });
     });
@@ -258,6 +260,49 @@ describe('hook mapper unit tests', () => {
       expect(mapHostHookResponse('Stop', response, { source: 'codex' })).toEqual({
         source: 'codex',
         continue: true,
+      });
+      expect(mapHostHookResponseForSource('codex', 'Stop', response)).toEqual({
+        continue: true,
+      });
+    });
+
+    it('filters stdout fields through host-specific output contracts', () => {
+      const hookSpecificOutput = {
+        hookEventName: 'SessionStart',
+        additionalContext: 'ready',
+      };
+
+      expect(finalizeHostHookOutput('claude-code', {
+        continue: true,
+        source: 'claude-code',
+        hookSpecificOutput,
+        systemMessage: 'unsupported by current Claude renderer',
+      })).toEqual({
+        continue: true,
+        source: 'claude-code',
+        hookSpecificOutput,
+      });
+
+      expect(finalizeHostHookOutput('codex', {
+        continue: true,
+        source: 'codex',
+        hookSpecificOutput,
+        systemMessage: 'allowed by Codex',
+      })).toEqual({
+        continue: true,
+        hookSpecificOutput,
+        systemMessage: 'allowed by Codex',
+      });
+
+      expect(finalizeHostHookOutput('future-host', {
+        continue: true,
+        source: 'future-host',
+        hookSpecificOutput,
+        systemMessage: 'requires explicit contract',
+        suppressOutput: true,
+      })).toEqual({
+        continue: true,
+        hookSpecificOutput,
       });
     });
 
@@ -286,7 +331,6 @@ describe('hook mapper unit tests', () => {
           result: { kind: 'json', data },
         })
       ).toEqual({
-        source: 'codex',
         continue: true,
       });
 
@@ -490,7 +534,7 @@ describe('hook round-trip integrations', () => {
         },
       },
       (output: ReturnType<typeof mapCodexResponse>) => {
-        expect(output.source).toBe('codex');
+        expect(output).not.toHaveProperty('source');
         expect(output.hookSpecificOutput?.hookEventName).toBe('Stop');
         expect(output.hookSpecificOutput?.additionalContext).toContain('feature-x');
       },

--- a/src/integrations/claude-code/hooks/mapClaudeCodeResponse.ts
+++ b/src/integrations/claude-code/hooks/mapClaudeCodeResponse.ts
@@ -2,7 +2,7 @@ import type { HarnessHookResponse } from '../../../harness';
 
 import {
   isSessionEndReentry,
-  mapHostHookResponse,
+  mapHostHookResponseForSource,
   type HostHookOutput,
 } from '../../shared';
 
@@ -17,8 +17,7 @@ export function mapClaudeCodeResponse(
   const hookEventName =
     typeof event.hook_event_name === 'string' ? event.hook_event_name : 'unknown';
 
-  return mapHostHookResponse(hookEventName, response, {
-    source: 'claude-code',
+  return mapHostHookResponseForSource('claude-code', hookEventName, response, {
     suppressAdditionalContext: isSessionEndReentry(event),
   });
 }

--- a/src/integrations/codex/hooks/mapCodexResponse.ts
+++ b/src/integrations/codex/hooks/mapCodexResponse.ts
@@ -2,13 +2,13 @@ import type { HarnessHookResponse } from '../../../harness';
 
 import {
   isSessionEndReentry,
-  mapHostHookResponse,
+  mapHostHookResponseForSource,
   type HostHookOutput,
 } from '../../shared';
 
 import type { CodexHookInput } from './mapCodexEvent';
 
-export type CodexHookOutput = HostHookOutput;
+export type CodexHookOutput = Omit<HostHookOutput, 'source'>;
 
 export function mapCodexResponse(
   event: CodexHookInput,
@@ -17,8 +17,7 @@ export function mapCodexResponse(
   const hookEventName =
     typeof event.hook_event_name === 'string' ? event.hook_event_name : 'unknown';
 
-  return mapHostHookResponse(hookEventName, response, {
-    source: 'codex',
+  return mapHostHookResponseForSource('codex', hookEventName, response, {
     suppressAdditionalContext: isSessionEndReentry(event),
-  });
+  }) as CodexHookOutput;
 }

--- a/src/integrations/shared/hostHookOutputContract.ts
+++ b/src/integrations/shared/hostHookOutputContract.ts
@@ -1,0 +1,56 @@
+import type { HarnessHookSource } from '../../harness';
+
+export interface HostHookOutput {
+  continue?: boolean;
+  source?: HarnessHookSource;
+  stopReason?: string;
+  suppressOutput?: boolean;
+  systemMessage?: string;
+  hookSpecificOutput?: {
+    hookEventName: string;
+    additionalContext?: string;
+  };
+}
+
+type HostHookOutputField = keyof HostHookOutput;
+
+const STRICT_COMMAND_HOOK_FIELDS = [
+  'continue',
+  'hookSpecificOutput',
+] as const satisfies readonly HostHookOutputField[];
+
+const HOST_HOOK_OUTPUT_FIELDS: Partial<Record<string, readonly HostHookOutputField[]>> = {
+  'claude-code': [
+    ...STRICT_COMMAND_HOOK_FIELDS,
+    'source',
+    'stopReason',
+    'suppressOutput',
+  ],
+  codex: [
+    ...STRICT_COMMAND_HOOK_FIELDS,
+    'stopReason',
+    'suppressOutput',
+    'systemMessage',
+  ],
+};
+
+export function getHostHookOutputFields(
+  source: HarnessHookSource
+): readonly HostHookOutputField[] {
+  return HOST_HOOK_OUTPUT_FIELDS[source] ?? STRICT_COMMAND_HOOK_FIELDS;
+}
+
+export function finalizeHostHookOutput(
+  source: HarnessHookSource,
+  output: HostHookOutput
+): HostHookOutput {
+  const sanitized: HostHookOutput = {};
+  const sanitizedRecord = sanitized as Record<string, unknown>;
+  const outputRecord = output as Record<string, unknown>;
+  for (const field of getHostHookOutputFields(source)) {
+    if (outputRecord[field] !== undefined) {
+      sanitizedRecord[field] = outputRecord[field];
+    }
+  }
+  return sanitized;
+}

--- a/src/integrations/shared/index.ts
+++ b/src/integrations/shared/index.ts
@@ -24,8 +24,14 @@ export {
 } from './hookRepoRootResolver';
 
 export {
-  mapHostHookResponse,
+  finalizeHostHookOutput,
+  getHostHookOutputFields,
   type HostHookOutput,
+} from './hostHookOutputContract';
+
+export {
+  mapHostHookResponse,
+  mapHostHookResponseForSource,
 } from './mapHostHookResponse';
 
 export {

--- a/src/integrations/shared/mapHostHookResponse.ts
+++ b/src/integrations/shared/mapHostHookResponse.ts
@@ -4,15 +4,10 @@ import {
   type HarnessHookResponse,
   type HarnessHookSource,
 } from '../../harness';
-
-export interface HostHookOutput {
-  continue?: boolean;
-  source?: HarnessHookSource;
-  hookSpecificOutput?: {
-    hookEventName: string;
-    additionalContext?: string;
-  };
-}
+import {
+  finalizeHostHookOutput,
+  type HostHookOutput,
+} from './hostHookOutputContract';
 
 const MISSING_CONTEXT_HINT =
   'dotcontext: this repository does not have .context/ yet.\nNext step: configure MCP and ask the agent to run context init in this project.';
@@ -104,7 +99,8 @@ function mapSuccessResponse(
 }
 
 /**
- * Map HarnessHookResponse to Claude/Codex stdout JSON control fields.
+ * Map HarnessHookResponse to protocol-neutral command hook stdout fields.
+ * Run the result through finalizeHostHookOutput before writing to a host.
  */
 export function mapHostHookResponse(
   hostEventName: string,
@@ -126,3 +122,20 @@ export function mapHostHookResponse(
     ...mapSuccessResponse(hostEventName, response, options?.source),
   };
 }
+
+export function mapHostHookResponseForSource(
+  source: HarnessHookSource,
+  hostEventName: string,
+  response: HarnessHookResponse,
+  options?: { suppressAdditionalContext?: boolean }
+): HostHookOutput {
+  return finalizeHostHookOutput(
+    source,
+    mapHostHookResponse(hostEventName, response, {
+      source,
+      suppressAdditionalContext: options?.suppressAdditionalContext,
+    })
+  );
+}
+
+export type { HostHookOutput } from './hostHookOutputContract';


### PR DESCRIPTION
## What changed

- Adds a host-specific hook stdout contract layer so each integration emits only fields allowed by its host.
- Routes Claude Code and Codex response mappers through the shared contract finalizer.
- Applies a final output sanitization pass in hook dispatch before writing stdout.
- Recovers stale or corrupt hook session bindings during `PostToolUse` trace append.
- Writes harness session metadata atomically to avoid partially written `session.json` files.

## Why

Codex rejects `SessionStart` hook output when unexpected top-level fields are present. The previous implementation allowed shared fields such as `source` to leak into Codex stdout. This PR moves that concern into a reusable integration contract so future hosts default to strict schema-safe output unless they explicitly opt in to extra fields.

## Validation

- `npm run build`
- `npm test -- --runInBand`

Both passed locally.
