### PR TITLE
Release 1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.1] - 2026-06-27
+
 ### Fixed
 
 - Removed the Codex-only `source` field from hook stdout so `SessionStart` output matches Codex's strict JSON schema.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dotcontext/cli",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dotcontext/cli",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcontext/cli",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "A harness for your harness — the contextual layer that keeps work going across any AI tool, with CLI, MCP, and host integration surfaces",
   "main": "dist/cli/index.js",
   "exports": {


### PR DESCRIPTION
## Summary

Prepare the 1.1.1 patch release.

## Changes

- Bump `@dotcontext/cli` from 1.1.0 to 1.1.1 in `package.json` and `package-lock.json`.
- Promote the existing hook fixes from `Unreleased` into the `1.1.1` changelog section.

## Impact

This release packages the Codex hook stdout/schema fixes and hook trace session recovery hardening without changing the public CLI surface beyond the patch version.

## Validation

- `npm run build`
- `npm test -- --runInBand` (92 suites, 564 tests)
- `npm run release:packages -- 1.1.1` (`build:packages` + `smoke:packages`, 5 bundles)
- `git diff --check`