### PR TITLE
fix(paths): normalize displayed paths to POSIX on Windows

### DIFF
--- a/src/harness/application/actions/workflowActionService.ts
+++ b/src/harness/application/actions/workflowActionService.ts
@@ -12,7 +12,7 @@ import {
 } from '../workflow';
 
 import { HarnessPolicyBlockedError } from '../policies/policyService';
-import { resolveRuntimeLayout } from '../../../shared/fs/pathHelpers';
+import { resolveRuntimeLayout, toPosixContextPath } from '../../../shared/fs/pathHelpers';
 import type { HarnessWorkflowGuideInput } from '../workflow/workflowGuideTypes';
 
 export interface HarnessWorkflowInitInput {
@@ -62,7 +62,7 @@ export class HarnessWorkflowActionService {
       archivePrevious: params.archive_previous,
     });
 
-    const workflowStatePath = resolveRuntimeLayout(contextPath).prevcFile;
+    const workflowStatePath = toPosixContextPath(resolveRuntimeLayout(contextPath).prevcFile);
     const settings = await service.getSettings();
     const scale = getScaleName(status.project.scale as ProjectScale);
     const isAutonomous = settings.autonomous_mode;
@@ -131,13 +131,13 @@ export class HarnessWorkflowActionService {
         error: 'No workflow found. Initialize a workflow first.',
         suggestion: 'Use workflow-init({ name: "feature-name" }) to start.',
         note: 'Workflows enable structured PREVC phases. Skip for trivial changes.',
-        workflowStatePath: resolveRuntimeLayout(contextPath).prevcFile,
+        workflowStatePath: toPosixContextPath(resolveRuntimeLayout(contextPath).prevcFile),
       };
     }
 
     const summary = await service.getSummary();
     const status = await service.getStatus();
-    const workflowStatePath = resolveRuntimeLayout(contextPath).prevcFile;
+    const workflowStatePath = toPosixContextPath(resolveRuntimeLayout(contextPath).prevcFile);
     const orchestration = await service.getPhaseOrchestration(summary.currentPhase);
     const harness = await service.getHarnessStatus();
 
@@ -170,7 +170,7 @@ export class HarnessWorkflowActionService {
         success: false,
         error: 'No workflow found. Initialize a workflow first.',
         suggestion: 'Use workflow-init({ name: "feature-name" }) to start.',
-        workflowStatePath: resolveRuntimeLayout(contextPath).prevcFile,
+        workflowStatePath: toPosixContextPath(resolveRuntimeLayout(contextPath).prevcFile),
       };
     }
 

--- a/src/harness/application/context/contextTools.ts
+++ b/src/harness/application/context/contextTools.ts
@@ -348,11 +348,11 @@ export const listFilesTool = createInternalTool<
   async (input) => {
     const { pattern, cwd, ignore } = input;
     try {
-      const files = await glob(pattern, {
+      const files = (await glob(pattern, {
         cwd: cwd || process.cwd(),
         ignore: ignore || ['node_modules/**', '.git/**', 'dist/**'],
         absolute: false
-      });
+      })).map((file) => file.split(path.sep).join('/'));
       return {
         success: true,
         files,

--- a/src/harness/application/workflow/plansService.ts
+++ b/src/harness/application/workflow/plansService.ts
@@ -15,7 +15,7 @@ import {
 } from '../../domain/workflow/plans';
 import { PrevcStatusManager } from '../../domain/workflow/status/statusManager';
 import { GitService } from '../../../utils/gitService';
-import { resolveRuntimeLayoutFromRepo } from '../../../shared/fs/pathHelpers';
+import { resolveRuntimeLayoutFromRepo, toPosixContextPath } from '../../../shared/fs/pathHelpers';
 import type { PrevcPhase } from '../../domain/workflow/types';
 
 export interface HarnessPlansServiceOptions {
@@ -87,7 +87,7 @@ export class HarnessPlansService {
       canAdvanceToReview = gateResult.gates.plan_required.passed;
     }
 
-    const workflowStatePath = resolveRuntimeLayoutFromRepo(this.repoPath).prevcFile;
+    const workflowStatePath = toPosixContextPath(resolveRuntimeLayoutFromRepo(this.repoPath).prevcFile);
     const enhancementPrompt = workflowActive
       ? `PLAN LINKED TO ACTIVE WORKFLOW
 

--- a/src/shared/fs/pathHelpers.ts
+++ b/src/shared/fs/pathHelpers.ts
@@ -246,6 +246,13 @@ export async function isFile(targetPath: string): Promise<boolean> {
 }
 
 /**
+ * Normalize an absolute path for cross-platform API responses (forward slashes).
+ */
+export function toPosixContextPath(absolutePath: string): string {
+  return absolutePath.split(path.sep).join('/');
+}
+
+/**
  * Normalize path separators to forward slashes
  */
 export function normalizePath(inputPath: string): string {

--- a/src/utils/splashScreen.ts
+++ b/src/utils/splashScreen.ts
@@ -60,8 +60,8 @@ export function formatSplashDirectory(directory: string, maxLength = 48): string
   const withTilde = resolved === homeDirectory
     ? '~'
     : resolved.startsWith(`${homeDirectory}${path.sep}`)
-      ? `~${path.sep}${path.relative(homeDirectory, resolved)}`
-      : resolved;
+      ? `~/${path.relative(homeDirectory, resolved).split(path.sep).join('/')}`
+      : resolved.split(path.sep).join('/');
 
   return truncateMiddle(withTilde, maxLength);
 }


### PR DESCRIPTION
## Bug

On Windows, several user-facing paths used native backslashes while tests and MCP clients expect forward slashes (POSIX-style), causing Jest failures on win32.

## Reproduction

`npm test` on Windows (Node 20+) fails for:
- `splashScreen › shortens home-directory paths with a tilde` (expected `~/workspace/...`, got `~\workspace\...`)
- `exploreActionService › uses the configured repo path as the default list cwd` (glob returned `src\example.ts`)
- `workflowManage › instructs the caller...` (`workflowStatePath` contained `C:\...\.context\runtime\...` instead of `.context/runtime/workflows/prevc.json` substring with forward slashes)

CI on Linux stays green; the bug is cross-platform consistency at API boundaries.

## Fix

- `formatSplashDirectory`: tilde-relative segments joined with `/`
- `listFilesTool`: normalize glob results with forward slashes
- `toPosixContextPath` helper + apply to `workflowStatePath` in workflow/plan responses

Verified locally: targeted Jest suites pass; `tsc --noEmit` clean.
