### PR TITLE
fix: own the LSP process lifecycle

### DIFF
--- a/src/harness/adapters/out/semantic/lsp/__tests__/fixtures/fake-lsp-server.js
+++ b/src/harness/adapters/out/semantic/lsp/__tests__/fixtures/fake-lsp-server.js
@@ -1,0 +1,71 @@
+'use strict';
+
+const fs = require('fs');
+
+const mode = process.argv[2] || 'normal';
+const pidFile = process.argv[3];
+if (pidFile) fs.appendFileSync(pidFile, `${process.pid}\n`);
+
+if (mode === 'ignore-shutdown') {
+  process.on('SIGTERM', () => {});
+}
+
+let input = Buffer.alloc(0);
+
+function send(message) {
+  const content = JSON.stringify(message);
+  process.stdout.write(`Content-Length: ${Buffer.byteLength(content)}\r\n\r\n${content}`);
+}
+
+function respond(message) {
+  if (message.method === 'initialize') {
+    if (mode === 'crash-after-spawn') {
+      process.exit(19);
+    } else if (mode === 'reject-initialize') {
+      send({ jsonrpc: '2.0', id: message.id, error: { code: -32002, message: 'initialize rejected' } });
+    } else if (mode !== 'timeout-initialize') {
+      send({ jsonrpc: '2.0', id: message.id, result: { capabilities: {} } });
+    }
+    return;
+  }
+
+  if (message.method === 'shutdown') {
+    if (mode !== 'ignore-shutdown') {
+      send({ jsonrpc: '2.0', id: message.id, result: null });
+    }
+    return;
+  }
+
+  if (message.method === 'exit') {
+    if (mode !== 'ignore-shutdown') process.exit(0);
+    return;
+  }
+
+  if (message.method === 'textDocument/hover') {
+    if (mode === 'crash-on-hover') process.exit(23);
+    send({ jsonrpc: '2.0', id: message.id, result: { contents: '```ts\nFakeType\n```' } });
+    return;
+  }
+
+  if (message.id !== undefined) send({ jsonrpc: '2.0', id: message.id, result: [] });
+}
+
+process.stdin.on('data', (data) => {
+  input = Buffer.concat([input, data]);
+  while (true) {
+    const headerEnd = input.indexOf('\r\n\r\n');
+    if (headerEnd < 0) return;
+    const header = input.subarray(0, headerEnd).toString('ascii');
+    const match = /Content-Length:\s*(\d+)/i.exec(header);
+    if (!match) process.exit(2);
+    const length = Number(match[1]);
+    const bodyStart = headerEnd + 4;
+    if (input.length < bodyStart + length) return;
+    const message = JSON.parse(input.subarray(bodyStart, bodyStart + length).toString('utf8'));
+    input = input.subarray(bodyStart + length);
+    respond(message);
+  }
+});
+
+// Keep the fixture alive after stdin closes so tests prove signal escalation.
+setInterval(() => {}, 1000);

--- a/src/harness/adapters/out/semantic/lsp/__tests__/fixtures/fake-lsp-server.js
+++ b/src/harness/adapters/out/semantic/lsp/__tests__/fixtures/fake-lsp-server.js
@@ -1,14 +1,22 @@
 'use strict';
 
 const fs = require('fs');
+const { spawn } = require('child_process');
+const { once } = require('events');
 
 const mode = process.argv[2] || 'normal';
 const pidFile = process.argv[3];
 const attackSize = Number(process.argv[4]) || 4096;
 if (pidFile) fs.appendFileSync(pidFile, `${process.pid}\n`);
 
-if (mode === 'ignore-shutdown') {
+if (mode.startsWith('ignore-shutdown') || mode === 'signal-ignoring-descendant') {
   process.on('SIGTERM', () => {});
+}
+
+if (mode === 'ignore-shutdown-with-descendant') {
+  spawn(process.execPath, [__filename, 'signal-ignoring-descendant', pidFile], {
+    stdio: ['ignore', 'inherit', 'inherit'],
+  });
 }
 
 let input = Buffer.alloc(0);
@@ -16,6 +24,21 @@ let input = Buffer.alloc(0);
 function send(message) {
   const content = JSON.stringify(message);
   process.stdout.write(`Content-Length: ${Buffer.byteLength(content)}\r\n\r\n${content}`);
+}
+
+async function sendFragmented(message, chunkSize = 1024) {
+  const content = JSON.stringify(message);
+  const frame = Buffer.from(
+    `Content-Length: ${Buffer.byteLength(content)}\r\n\r\n${content}`
+  );
+  for (let offset = 0; offset < frame.length; offset += chunkSize) {
+    const chunk = frame.subarray(offset, Math.min(offset + chunkSize, frame.length));
+    if (!process.stdout.write(chunk)) await once(process.stdout, 'drain');
+    // Keep writes observably fragmented instead of filling the pipe in one turn.
+    if (offset > 0 && offset % (chunkSize * 64) === 0) {
+      await new Promise((resolve) => setImmediate(resolve));
+    }
+  }
 }
 
 function respond(message) {
@@ -32,6 +55,12 @@ function respond(message) {
       process.exit(19);
     } else if (mode === 'reject-initialize') {
       send({ jsonrpc: '2.0', id: message.id, error: { code: -32002, message: 'initialize rejected' } });
+    } else if (mode === 'fragmented-large-initialize') {
+      void sendFragmented({
+        jsonrpc: '2.0',
+        id: message.id,
+        result: { capabilities: {}, padding: 'x'.repeat(attackSize) },
+      });
     } else if (mode !== 'timeout-initialize') {
       send({ jsonrpc: '2.0', id: message.id, result: { capabilities: {} } });
     }
@@ -39,14 +68,14 @@ function respond(message) {
   }
 
   if (message.method === 'shutdown') {
-    if (mode !== 'ignore-shutdown') {
+    if (!mode.startsWith('ignore-shutdown')) {
       send({ jsonrpc: '2.0', id: message.id, result: null });
     }
     return;
   }
 
   if (message.method === 'exit') {
-    if (mode !== 'ignore-shutdown') process.exit(0);
+    if (!mode.startsWith('ignore-shutdown')) process.exit(0);
     return;
   }
 

--- a/src/harness/adapters/out/semantic/lsp/__tests__/fixtures/fake-lsp-server.js
+++ b/src/harness/adapters/out/semantic/lsp/__tests__/fixtures/fake-lsp-server.js
@@ -4,6 +4,7 @@ const fs = require('fs');
 
 const mode = process.argv[2] || 'normal';
 const pidFile = process.argv[3];
+const attackSize = Number(process.argv[4]) || 4096;
 if (pidFile) fs.appendFileSync(pidFile, `${process.pid}\n`);
 
 if (mode === 'ignore-shutdown') {
@@ -19,7 +20,15 @@ function send(message) {
 
 function respond(message) {
   if (message.method === 'initialize') {
-    if (mode === 'crash-after-spawn') {
+    if (mode === 'incomplete-huge-header') {
+      process.stdout.write('X'.repeat(attackSize));
+    } else if (mode === 'incomplete-huge-body') {
+      process.stdout.write(
+        `Content-Length: ${attackSize * 2}\r\n\r\n${'X'.repeat(attackSize)}`
+      );
+    } else if (mode === 'abusive-content-length') {
+      process.stdout.write('Content-Length: 999999999999999999999999\r\n\r\n');
+    } else if (mode === 'crash-after-spawn') {
       process.exit(19);
     } else if (mode === 'reject-initialize') {
       send({ jsonrpc: '2.0', id: message.id, error: { code: -32002, message: 'initialize rejected' } });

--- a/src/harness/adapters/out/semantic/lsp/__tests__/lspLayer.lifecycle.test.ts
+++ b/src/harness/adapters/out/semantic/lsp/__tests__/lspLayer.lifecycle.test.ts
@@ -1,20 +1,40 @@
 import * as fs from 'fs/promises';
 import * as os from 'os';
 import * as path from 'path';
+import type { ChildProcess } from 'child_process';
 import { LSPLayer, LSPLayerOptions, LSPLifecycleEvent } from '../lspLayer';
 import type { LSPServerConfig } from '../../types';
 
 const FIXTURE = path.join(__dirname, 'fixtures', 'fake-lsp-server.js');
 const TIMEOUT_MS = 150;
 
-function server(mode: string, pidFile: string): LSPServerConfig {
-  return { command: process.execPath, args: [FIXTURE, mode, pidFile] };
+function server(mode: string, pidFile: string, attackSize?: number): LSPServerConfig {
+  const args = [FIXTURE, mode, pidFile];
+  if (attackSize !== undefined) args.push(String(attackSize));
+  return { command: process.execPath, args };
 }
 
-async function waitUntil(predicate: () => boolean, timeoutMs = 2_000): Promise<void> {
+interface InspectableHandle {
+  process: ChildProcess;
+  pendingRequests: Map<number, unknown>;
+  timers: Set<NodeJS.Timeout>;
+  buffer: Buffer;
+}
+
+function currentHandle(subject: LSPLayer): InspectableHandle {
+  const handles = (subject as unknown as { handles: Map<string, InspectableHandle> }).handles;
+  const [handle] = [...handles.values()];
+  if (!handle) throw new Error('expected an active LSP handle');
+  return handle;
+}
+
+async function waitUntil(
+  predicate: () => boolean | Promise<boolean>,
+  timeoutMs = 2_000
+): Promise<void> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
-    if (predicate()) return;
+    if (await predicate()) return;
     await new Promise((resolve) => setTimeout(resolve, 10));
   }
   throw new Error('condition did not become true before timeout');
@@ -103,6 +123,65 @@ describe('LSPLayer process lifecycle', () => {
     await waitUntil(() => !processIsAlive(pid));
   });
 
+  it.each([
+    {
+      name: 'incomplete huge header',
+      mode: 'incomplete-huge-header',
+      attackSize: 4096,
+      overrides: { maxHeaderBytes: 1024, maxReceiveBufferBytes: 8192 },
+      reason: /header limit exceeded/,
+    },
+    {
+      name: 'incomplete huge body',
+      mode: 'incomplete-huge-body',
+      attackSize: 4096,
+      overrides: { maxBodyBytes: 8192, maxReceiveBufferBytes: 2048 },
+      reason: /receive buffer limit exceeded|frame exceeds receive buffer limit/,
+    },
+    {
+      name: 'abusive Content-Length',
+      mode: 'abusive-content-length',
+      attackSize: 4096,
+      overrides: { maxBodyBytes: 8192 },
+      reason: /Content-Length exceeds body limit/,
+    },
+    {
+      name: 'caller attempt to raise the absolute header maximum',
+      mode: 'incomplete-huge-header',
+      attackSize: 32 * 1024,
+      overrides: { maxHeaderBytes: Number.MAX_SAFE_INTEGER },
+      reason: /header limit exceeded/,
+    },
+  ])('terminates and opens the circuit for $name', async ({
+    mode,
+    attackSize,
+    overrides,
+    reason,
+  }) => {
+    const events: LSPLifecycleEvent[] = [];
+    const subject = createLayer(
+      { typescript: server(mode, pidFile, attackSize) },
+      { ...overrides, onLifecycleEvent: (event) => events.push(event) }
+    );
+
+    const initialization = subject.ensureServer('typescript', projectPath);
+    const handle = currentHandle(subject);
+    await expect(initialization).resolves.toBe(false);
+    const [pid] = await readPids(pidFile);
+    expect(pid).toBeDefined();
+    await waitUntil(() => !processIsAlive(pid));
+    expect(events).toEqual(expect.arrayContaining([
+      expect.objectContaining({ state: 'failed', reason: expect.stringMatching(reason) }),
+      expect.objectContaining({ state: 'stopped', pendingRequestCount: 0 }),
+    ]));
+    expect(handle.pendingRequests.size).toBe(0);
+    expect(handle.timers.size).toBe(0);
+    expect(handle.buffer).toHaveLength(0);
+
+    await expect(subject.ensureServer('typescript', projectPath)).resolves.toBe(false);
+    expect(await readPids(pidFile)).toEqual([pid]);
+  });
+
   it('deduplicates concurrent initialization for the same language and project', async () => {
     const subject = createLayer({ typescript: server('normal', pidFile) });
 
@@ -159,5 +238,40 @@ describe('LSPLayer process lifecycle', () => {
       ])
     );
     await expect(subject.shutdown()).resolves.toBeUndefined();
+  });
+
+  it('is safe when shutdown races with initialization', async () => {
+    const subject = createLayer({ typescript: server('timeout-initialize', pidFile) });
+
+    const initialization = subject.ensureServer('typescript', projectPath);
+    await waitUntil(async () => (await readPids(pidFile)).length === 1);
+    const [pid] = await readPids(pidFile);
+    const handle = currentHandle(subject);
+
+    await expect(Promise.all([initialization, subject.shutdown()])).resolves.toEqual([
+      false,
+      undefined,
+    ]);
+    expect(processIsAlive(pid)).toBe(false);
+    expect(handle.pendingRequests.size).toBe(0);
+    expect(handle.timers.size).toBe(0);
+  });
+
+  it('removes final listeners, timers, buffers, and process handles after shutdown', async () => {
+    const subject = createLayer({ typescript: server('normal', pidFile) });
+    await expect(subject.ensureServer('typescript', projectPath)).resolves.toBe(true);
+    const [pid] = await readPids(pidFile);
+    const handle = currentHandle(subject);
+
+    await subject.shutdown();
+
+    expect(processIsAlive(pid)).toBe(false);
+    expect(handle.pendingRequests.size).toBe(0);
+    expect(handle.timers.size).toBe(0);
+    expect(handle.buffer).toHaveLength(0);
+    expect(handle.process.eventNames()).toEqual([]);
+    expect(handle.process.stdin?.eventNames()).toEqual([]);
+    expect(handle.process.stdout?.eventNames()).toEqual([]);
+    expect(handle.process.stderr?.eventNames()).toEqual([]);
   });
 });

--- a/src/harness/adapters/out/semantic/lsp/__tests__/lspLayer.lifecycle.test.ts
+++ b/src/harness/adapters/out/semantic/lsp/__tests__/lspLayer.lifecycle.test.ts
@@ -1,0 +1,163 @@
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import { LSPLayer, LSPLayerOptions, LSPLifecycleEvent } from '../lspLayer';
+import type { LSPServerConfig } from '../../types';
+
+const FIXTURE = path.join(__dirname, 'fixtures', 'fake-lsp-server.js');
+const TIMEOUT_MS = 150;
+
+function server(mode: string, pidFile: string): LSPServerConfig {
+  return { command: process.execPath, args: [FIXTURE, mode, pidFile] };
+}
+
+async function waitUntil(predicate: () => boolean, timeoutMs = 2_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error('condition did not become true before timeout');
+}
+
+function processIsAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function readPids(pidFile: string): Promise<number[]> {
+  try {
+    return (await fs.readFile(pidFile, 'utf8'))
+      .trim()
+      .split('\n')
+      .filter(Boolean)
+      .map(Number);
+  } catch {
+    return [];
+  }
+}
+
+describe('LSPLayer process lifecycle', () => {
+  let projectPath: string;
+  let pidFile: string;
+  let layer: LSPLayer | undefined;
+
+  beforeEach(async () => {
+    projectPath = await fs.mkdtemp(path.join(os.tmpdir(), 'dotcontext-lsp-'));
+    pidFile = path.join(projectPath, 'pids');
+  });
+
+  afterEach(async () => {
+    await layer?.shutdown();
+    const pids = await readPids(pidFile);
+    await Promise.all(pids.map((pid) => waitUntil(() => !processIsAlive(pid))));
+    await fs.rm(projectPath, { recursive: true, force: true });
+  });
+
+  function createLayer(
+    configs: Record<string, LSPServerConfig>,
+    overrides: LSPLayerOptions = {}
+  ): LSPLayer {
+    layer = new LSPLayer({
+      serverConfigs: configs,
+      requestTimeoutMs: TIMEOUT_MS,
+      shutdownTimeoutMs: TIMEOUT_MS,
+      terminationGraceMs: TIMEOUT_MS,
+      ...overrides,
+    });
+    return layer;
+  }
+
+  it('terminates the child after initialize rejection and suppresses retries', async () => {
+    const subject = createLayer({ typescript: server('reject-initialize', pidFile) });
+
+    await expect(subject.ensureServer('typescript', projectPath)).resolves.toBe(false);
+    const [pid] = await readPids(pidFile);
+    expect(pid).toBeDefined();
+    await waitUntil(() => !processIsAlive(pid));
+
+    await expect(subject.ensureServer('typescript', projectPath)).resolves.toBe(false);
+    await expect(subject.getTypeInfo(path.join(projectPath, 'a.ts'), 1, 0, projectPath)).resolves.toBeNull();
+    expect(await readPids(pidFile)).toEqual([pid]);
+  });
+
+  it('terminates the child after initialize timeout', async () => {
+    const subject = createLayer({ typescript: server('timeout-initialize', pidFile) });
+
+    await expect(subject.ensureServer('typescript', projectPath)).resolves.toBe(false);
+    const [pid] = await readPids(pidFile);
+    expect(pid).toBeDefined();
+    await waitUntil(() => !processIsAlive(pid));
+  });
+
+  it('cleans up when the child crashes during initialization', async () => {
+    const subject = createLayer({ typescript: server('crash-after-spawn', pidFile) });
+
+    await expect(subject.ensureServer('typescript', projectPath)).resolves.toBe(false);
+    const [pid] = await readPids(pidFile);
+    expect(pid).toBeDefined();
+    await waitUntil(() => !processIsAlive(pid));
+  });
+
+  it('deduplicates concurrent initialization for the same language and project', async () => {
+    const subject = createLayer({ typescript: server('normal', pidFile) });
+
+    await expect(
+      Promise.all([
+        subject.ensureServer('typescript', projectPath),
+        subject.ensureServer('typescript', projectPath),
+        subject.ensureServer('typescript', projectPath),
+      ])
+    ).resolves.toEqual([true, true, true]);
+    expect(await readPids(pidFile)).toHaveLength(1);
+  });
+
+  it('does not reject another language request when one server crashes', async () => {
+    const subject = createLayer({
+      typescript: server('crash-on-hover', pidFile),
+      javascript: server('normal', pidFile),
+    });
+    await Promise.all([
+      subject.ensureServer('typescript', projectPath),
+      subject.ensureServer('javascript', projectPath),
+    ]);
+
+    const [failedResult, healthyResult] = await Promise.all([
+      subject.getTypeInfo(path.join(projectPath, 'a.ts'), 1, 0, projectPath),
+      subject.getTypeInfo(path.join(projectPath, 'a.js'), 1, 0, projectPath),
+    ]);
+
+    expect(failedResult).toBeNull();
+    expect(healthyResult?.name).toBe('FakeType');
+  });
+
+  it('forces termination and waits for child exit when shutdown is ignored', async () => {
+    const events: LSPLifecycleEvent[] = [];
+    const subject = createLayer(
+      { typescript: server('ignore-shutdown', pidFile) },
+      { onLifecycleEvent: (event) => events.push(event) }
+    );
+    await expect(subject.ensureServer('typescript', projectPath)).resolves.toBe(true);
+    const [pid] = await readPids(pidFile);
+    expect(processIsAlive(pid)).toBe(true);
+
+    await subject.shutdown();
+
+    expect(processIsAlive(pid)).toBe(false);
+    expect(events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          language: 'typescript',
+          state: 'stopped',
+          forcedKill: true,
+          exitSignal: 'SIGKILL',
+        }),
+      ])
+    );
+    await expect(subject.shutdown()).resolves.toBeUndefined();
+  });
+});

--- a/src/harness/adapters/out/semantic/lsp/__tests__/lspLayer.lifecycle.test.ts
+++ b/src/harness/adapters/out/semantic/lsp/__tests__/lspLayer.lifecycle.test.ts
@@ -2,7 +2,12 @@ import * as fs from 'fs/promises';
 import * as os from 'os';
 import * as path from 'path';
 import type { ChildProcess } from 'child_process';
-import { LSPLayer, LSPLayerOptions, LSPLifecycleEvent } from '../lspLayer';
+import {
+  LSPLayer,
+  LSPLayerOptions,
+  LSPLifecycleEvent,
+  MAX_LSP_BODY_BYTES,
+} from '../lspLayer';
 import type { LSPServerConfig } from '../../types';
 
 const FIXTURE = path.join(__dirname, 'fixtures', 'fake-lsp-server.js');
@@ -18,7 +23,7 @@ interface InspectableHandle {
   process: ChildProcess;
   pendingRequests: Map<number, unknown>;
   timers: Set<NodeJS.Timeout>;
-  buffer: Buffer;
+  receiver: { bufferedByteLength: number };
 }
 
 function currentHandle(subject: LSPLayer): InspectableHandle {
@@ -176,7 +181,7 @@ describe('LSPLayer process lifecycle', () => {
     ]));
     expect(handle.pendingRequests.size).toBe(0);
     expect(handle.timers.size).toBe(0);
-    expect(handle.buffer).toHaveLength(0);
+    expect(handle.receiver.bufferedByteLength).toBe(0);
 
     await expect(subject.ensureServer('typescript', projectPath)).resolves.toBe(false);
     expect(await readPids(pidFile)).toEqual([pid]);
@@ -240,6 +245,46 @@ describe('LSPLayer process lifecycle', () => {
     await expect(subject.shutdown()).resolves.toBeUndefined();
   });
 
+  it('kills a signal-ignoring descendant in the owned process group', async () => {
+    const events: LSPLifecycleEvent[] = [];
+    const subject = createLayer(
+      { typescript: server('ignore-shutdown-with-descendant', pidFile) },
+      { onLifecycleEvent: (event) => events.push(event) }
+    );
+    await expect(subject.ensureServer('typescript', projectPath)).resolves.toBe(true);
+    await waitUntil(async () => (await readPids(pidFile)).length === 2);
+    const pids = await readPids(pidFile);
+    expect(pids).toHaveLength(2);
+    expect(pids.every(processIsAlive)).toBe(true);
+
+    const startedAt = Date.now();
+    await subject.shutdown();
+
+    expect(Date.now() - startedAt).toBeLessThan(2_000);
+    await Promise.all(pids.map((pid) => waitUntil(() => !processIsAlive(pid))));
+    expect(events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ state: 'stopped', forcedKill: true }),
+      ])
+    );
+  });
+
+  it('accepts a near-8MiB response fragmented into 1KiB writes', async () => {
+    const subject = createLayer(
+      {
+        typescript: server(
+          'fragmented-large-initialize',
+          pidFile,
+          MAX_LSP_BODY_BYTES - 1024
+        ),
+      },
+      { requestTimeoutMs: 15_000 }
+    );
+
+    await expect(subject.ensureServer('typescript', projectPath)).resolves.toBe(true);
+    expect(currentHandle(subject).receiver.bufferedByteLength).toBe(0);
+  }, 20_000);
+
   it('is safe when shutdown races with initialization', async () => {
     const subject = createLayer({ typescript: server('timeout-initialize', pidFile) });
 
@@ -268,7 +313,7 @@ describe('LSPLayer process lifecycle', () => {
     expect(processIsAlive(pid)).toBe(false);
     expect(handle.pendingRequests.size).toBe(0);
     expect(handle.timers.size).toBe(0);
-    expect(handle.buffer).toHaveLength(0);
+    expect(handle.receiver.bufferedByteLength).toBe(0);
     expect(handle.process.eventNames()).toEqual([]);
     expect(handle.process.stdin?.eventNames()).toEqual([]);
     expect(handle.process.stdout?.eventNames()).toEqual([]);

--- a/src/harness/adapters/out/semantic/lsp/index.ts
+++ b/src/harness/adapters/out/semantic/lsp/index.ts
@@ -1,1 +1,6 @@
 export { LSPLayer } from './lspLayer';
+export type {
+  LSPLayerOptions,
+  LSPLifecycleEvent,
+  LSPServerState,
+} from './lspLayer';

--- a/src/harness/adapters/out/semantic/lsp/lspLayer.ts
+++ b/src/harness/adapters/out/semantic/lsp/lspLayer.ts
@@ -5,7 +5,7 @@
  * initialization and shutdown state therefore cannot leak across servers.
  */
 
-import { spawn, ChildProcess } from 'child_process';
+import { spawn, execFile, ChildProcess } from 'child_process';
 import { createHash } from 'crypto';
 import * as path from 'path';
 import {
@@ -58,15 +58,138 @@ interface ServerHandle {
   stopping?: Promise<void>;
   pendingRequests: Map<number, PendingRequest>;
   timers: Set<NodeJS.Timeout>;
-  buffer: Buffer;
+  receiver: LSPFrameAccumulator;
   startedAt: number;
   terminationReason?: string;
   forcedKill: boolean;
+  exited: boolean;
   closed: boolean;
-  closePromise: Promise<void>;
-  resolveClose: () => void;
   exitCode?: number | null;
   exitSignal?: NodeJS.Signals | null;
+}
+
+/**
+ * Incrementally assembles one LSP frame without repeatedly copying all bytes
+ * received so far. Header segments are joined once after the delimiter and
+ * body bytes are copied directly into their final, bounded allocation.
+ */
+class LSPFrameAccumulator {
+  private readonly headerSegments: Buffer[] = [];
+  private headerLength = 0;
+  private headerDelimiterMatch = 0;
+  private body?: Buffer;
+  private bodyOffset = 0;
+
+  constructor(
+    private readonly maxHeaderBytes: number,
+    private readonly maxBodyBytes: number,
+    private readonly maxReceiveBufferBytes: number
+  ) {}
+
+  get bufferedByteLength(): number {
+    return this.headerLength + this.bodyOffset;
+  }
+
+  accept(data: Buffer, onFrame: (body: Buffer) => void): string | undefined {
+    let offset = 0;
+
+    while (offset < data.length) {
+      if (this.body) {
+        const copyLength = Math.min(data.length - offset, this.body.length - this.bodyOffset);
+        data.copy(this.body, this.bodyOffset, offset, offset + copyLength);
+        offset += copyLength;
+        this.bodyOffset += copyLength;
+
+        if (this.bodyOffset === this.body.length) {
+          const completedBody = this.body;
+          this.body = undefined;
+          this.bodyOffset = 0;
+          onFrame(completedBody);
+        }
+        continue;
+      }
+
+      const segmentStart = offset;
+      let foundHeader = false;
+      while (offset < data.length) {
+        const byte = data[offset++];
+        this.headerLength += 1;
+        this.headerDelimiterMatch = this.nextDelimiterMatch(
+          this.headerDelimiterMatch,
+          byte
+        );
+
+        if (this.headerDelimiterMatch === 4) {
+          this.headerSegments.push(data.subarray(segmentStart, offset));
+          foundHeader = true;
+          break;
+        }
+
+        // Bytes matching the start of CRLFCRLF may still be the delimiter and
+        // therefore are not counted as header content until the match fails.
+        if (this.headerLength - this.headerDelimiterMatch > this.maxHeaderBytes) {
+          return 'incomplete header limit exceeded';
+        }
+        if (this.headerLength > this.maxReceiveBufferBytes) {
+          return 'receive buffer limit exceeded';
+        }
+      }
+
+      if (!foundHeader) {
+        this.headerSegments.push(data.subarray(segmentStart, offset));
+        return undefined;
+      }
+
+      const headerEnd = this.headerLength - 4;
+      if (headerEnd > this.maxHeaderBytes) return 'header limit exceeded';
+      const headerBuffer = Buffer.concat(this.headerSegments, this.headerLength);
+      const header = headerBuffer.subarray(0, headerEnd).toString('ascii');
+      const contentLengthHeaders = header
+        .split('\r\n')
+        .filter((line) => /^Content-Length:/i.test(line));
+      if (contentLengthHeaders.length !== 1) {
+        return 'expected exactly one Content-Length header';
+      }
+      const rawContentLength = contentLengthHeaders[0]
+        .slice(contentLengthHeaders[0].indexOf(':') + 1)
+        .trim();
+      if (!/^[0-9]+$/.test(rawContentLength)) return 'invalid Content-Length';
+
+      const contentLength = Number(rawContentLength);
+      if (
+        !Number.isSafeInteger(contentLength) ||
+        contentLength <= 0 ||
+        contentLength > this.maxBodyBytes
+      ) {
+        return 'Content-Length exceeds body limit';
+      }
+      if (this.headerLength + contentLength > this.maxReceiveBufferBytes) {
+        return 'frame exceeds receive buffer limit';
+      }
+
+      this.headerSegments.length = 0;
+      this.headerLength = 0;
+      this.headerDelimiterMatch = 0;
+      this.body = Buffer.allocUnsafe(contentLength);
+      this.bodyOffset = 0;
+    }
+
+    return undefined;
+  }
+
+  reset(): void {
+    this.headerSegments.length = 0;
+    this.headerLength = 0;
+    this.headerDelimiterMatch = 0;
+    this.body = undefined;
+    this.bodyOffset = 0;
+  }
+
+  private nextDelimiterMatch(current: number, byte: number): number {
+    const delimiter = [13, 10, 13, 10];
+    if (byte === delimiter[current]) return current + 1;
+    return byte === delimiter[0] ? 1 : 0;
+  }
 }
 
 export interface LSPLayerOptions {
@@ -165,14 +288,14 @@ export class LSPLayer {
     const config = this.serverConfigs[language];
     if (!config) return false;
 
-    let resolveClose!: () => void;
-    const closePromise = new Promise<void>((resolve) => {
-      resolveClose = resolve;
-    });
     const child = spawn(config.command, config.args, {
       cwd: projectPath,
       stdio: ['pipe', 'pipe', 'pipe'],
       env: { ...process.env },
+      // A dedicated POSIX process group lets the owner terminate launchers and
+      // every descendant they create. Windows uses taskkill /T below.
+      detached: process.platform !== 'win32',
+      windowsHide: true,
     });
 
     const handle: ServerHandle = {
@@ -184,12 +307,15 @@ export class LSPLayer {
       initialization: Promise.resolve(false),
       pendingRequests: new Map(),
       timers: new Set(),
-      buffer: Buffer.alloc(0),
+      receiver: new LSPFrameAccumulator(
+        this.maxHeaderBytes,
+        this.maxBodyBytes,
+        this.maxReceiveBufferBytes
+      ),
       startedAt: Date.now(),
       forcedKill: false,
+      exited: false,
       closed: false,
-      closePromise,
-      resolveClose,
     };
 
     // Publish the owner before any asynchronous event can act on the process.
@@ -231,15 +357,21 @@ export class LSPLayer {
           exitSignal: signal,
         });
         this.rejectPending(handle, new Error(`LSP server ${handle.language} disconnected`));
-        this.releaseHandle(handle);
+        // The direct launcher may have left descendants in its process group.
+        // Termination remains authoritative even after the launcher closes.
+        void this.terminateHandle(handle, handle.terminationReason);
       }
+    });
+    handle.process.once('exit', (code, signal) => {
+      handle.exited = true;
+      handle.exitCode = code;
+      handle.exitSignal = signal;
     });
   }
 
   private markClosed(handle: ServerHandle): void {
     if (handle.closed) return;
     handle.closed = true;
-    handle.resolveClose();
   }
 
   private async initializeHandle(handle: ServerHandle): Promise<boolean> {
@@ -313,66 +445,14 @@ export class LSPLayer {
 
   private handleServerData(handle: ServerHandle, data: Buffer): void {
     if (handle.state === 'stopping' || handle.state === 'stopped') return;
-    if (data.length > this.maxReceiveBufferBytes - handle.buffer.length) {
-      this.failProtocol(handle, 'receive buffer limit exceeded');
-      return;
-    }
-    handle.buffer = Buffer.concat([handle.buffer, data]);
-
-    while (true) {
-      const headerEnd = handle.buffer.indexOf('\r\n\r\n');
-      if (headerEnd < 0) {
-        if (handle.buffer.length > this.maxHeaderBytes) {
-          this.failProtocol(handle, 'incomplete header limit exceeded');
-        }
-        return;
-      }
-      if (headerEnd > this.maxHeaderBytes) {
-        this.failProtocol(handle, 'header limit exceeded');
-        return;
-      }
-      const header = handle.buffer.subarray(0, headerEnd).toString('ascii');
-      const contentLengthHeaders = header
-        .split('\r\n')
-        .filter((line) => /^Content-Length:/i.test(line));
-      if (contentLengthHeaders.length !== 1) {
-        this.failProtocol(handle, 'expected exactly one Content-Length header');
-        return;
-      }
-      const rawContentLength = contentLengthHeaders[0].slice(
-        contentLengthHeaders[0].indexOf(':') + 1
-      ).trim();
-      if (!/^[0-9]+$/.test(rawContentLength)) {
-        this.failProtocol(handle, 'invalid Content-Length');
-        return;
-      }
-      const contentLength = Number(rawContentLength);
-      if (
-        !Number.isSafeInteger(contentLength) ||
-        contentLength <= 0 ||
-        contentLength > this.maxBodyBytes
-      ) {
-        this.failProtocol(handle, 'Content-Length exceeds body limit');
-        return;
-      }
-      const bodyStart = headerEnd + 4;
-      if (bodyStart + contentLength > this.maxReceiveBufferBytes) {
-        this.failProtocol(handle, 'frame exceeds receive buffer limit');
-        return;
-      }
-      if (handle.buffer.length < bodyStart + contentLength) return;
-
-      const body = handle.buffer.subarray(bodyStart, bodyStart + contentLength);
-      const remainingStart = bodyStart + contentLength;
-      handle.buffer = remainingStart === handle.buffer.length
-        ? Buffer.alloc(0)
-        : Buffer.from(handle.buffer.subarray(remainingStart));
+    const error = handle.receiver.accept(data, (body) => {
       try {
         this.handleMessage(handle, JSON.parse(body.toString('utf8')) as LSPMessage);
       } catch {
         // Malformed server messages are ignored without affecting another handle.
       }
-    }
+    });
+    if (error) this.failProtocol(handle, error);
   }
 
   private failProtocol(handle: ServerHandle, detail: string): void {
@@ -383,7 +463,7 @@ export class LSPLayer {
     ) return;
 
     const reason = `protocol overflow: ${detail}`;
-    handle.buffer = Buffer.alloc(0);
+    handle.receiver.reset();
     handle.terminationReason = reason;
     handle.state = 'failed';
     this.failedCircuits.add(handle.key);
@@ -465,15 +545,18 @@ export class LSPLayer {
       this.rejectPending(handle, new Error(`LSP server ${handle.language} terminated: ${reason}`));
       handle.process.stdin?.end();
 
-      if (!handle.closed) {
+      if (this.processTreeIsAlive(handle)) {
         const exitedNaturally =
-          waitForNaturalExit && (await this.waitForClose(handle, this.terminationGraceMs));
+          waitForNaturalExit &&
+          (await this.waitForProcessTreeExit(handle, this.terminationGraceMs));
         if (!exitedNaturally) {
-          this.signal(handle, 'SIGTERM');
-          if (!(await this.waitForClose(handle, this.terminationGraceMs))) {
+          await this.signalProcessTree(handle, 'SIGTERM');
+          if (!(await this.waitForProcessTreeExit(handle, this.terminationGraceMs))) {
             handle.forcedKill = true;
-            this.signal(handle, 'SIGKILL');
-            await handle.closePromise;
+            await this.signalProcessTree(handle, 'SIGKILL');
+            // Some descendants inherit the server's stdio and can prevent the
+            // ChildProcess `close` event. Never await it without a deadline.
+            await this.waitForProcessTreeExit(handle, this.terminationGraceMs);
           }
         }
       }
@@ -490,8 +573,27 @@ export class LSPLayer {
     return handle.stopping;
   }
 
-  private signal(handle: ServerHandle, signal: NodeJS.Signals): void {
-    if (handle.closed || !handle.process.pid) return;
+  private async signalProcessTree(
+    handle: ServerHandle,
+    signal: 'SIGTERM' | 'SIGKILL'
+  ): Promise<void> {
+    const pid = handle.process.pid;
+    if (!pid) return;
+
+    if (process.platform === 'win32') {
+      await this.taskkill(pid, signal === 'SIGKILL');
+      return;
+    }
+
+    try {
+      // Negative PID targets the dedicated group created with detached=true.
+      process.kill(-pid, signal);
+      return;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ESRCH') return;
+    }
+
+    // Fall back to the direct child if group signalling is unavailable.
     try {
       handle.process.kill(signal);
     } catch {
@@ -499,15 +601,44 @@ export class LSPLayer {
     }
   }
 
-  private waitForClose(handle: ServerHandle, timeoutMs: number): Promise<boolean> {
-    if (handle.closed) return Promise.resolve(true);
+  private taskkill(pid: number, force: boolean): Promise<void> {
     return new Promise((resolve) => {
-      const timeout = this.setHandleTimeout(handle, () => resolve(false), timeoutMs);
-      handle.closePromise.then(() => {
-        this.clearHandleTimeout(handle, timeout);
-        resolve(true);
-      });
+      const args = ['/PID', String(pid), '/T'];
+      if (force) args.push('/F');
+      execFile(
+        'taskkill',
+        args,
+        { windowsHide: true, timeout: Math.max(100, this.terminationGraceMs) },
+        () => resolve()
+      );
     });
+  }
+
+  private processTreeIsAlive(handle: ServerHandle): boolean {
+    const pid = handle.process.pid;
+    if (!pid) return false;
+    if (process.platform === 'win32') return !handle.exited;
+    try {
+      process.kill(-pid, 0);
+      return true;
+    } catch (error) {
+      return (error as NodeJS.ErrnoException).code === 'EPERM';
+    }
+  }
+
+  private async waitForProcessTreeExit(
+    handle: ServerHandle,
+    timeoutMs: number
+  ): Promise<boolean> {
+    const deadline = Date.now() + timeoutMs;
+    while (this.processTreeIsAlive(handle)) {
+      const remaining = deadline - Date.now();
+      if (remaining <= 0) return false;
+      await new Promise<void>((resolve) => {
+        this.setHandleTimeout(handle, resolve, Math.min(25, remaining));
+      });
+    }
+    return true;
   }
 
   private setHandleTimeout(
@@ -533,7 +664,7 @@ export class LSPLayer {
     this.rejectPending(handle, new Error(`LSP server ${handle.language} released`));
     for (const timer of handle.timers) clearTimeout(timer);
     handle.timers.clear();
-    handle.buffer = Buffer.alloc(0);
+    handle.receiver.reset();
     handle.process.stdin?.removeAllListeners();
     handle.process.stdout?.removeAllListeners();
     handle.process.stderr?.removeAllListeners();

--- a/src/harness/adapters/out/semantic/lsp/lspLayer.ts
+++ b/src/harness/adapters/out/semantic/lsp/lspLayer.ts
@@ -1,11 +1,12 @@
 /**
- * LSP Layer - Language Server Protocol integration for semantic analysis
+ * LSP Layer - Language Server Protocol integration for semantic analysis.
  *
- * Provides deeper semantic understanding through LSP servers.
- * This layer is lazily initialized and optional.
+ * Every child process is owned by one ServerHandle. Buffers, pending requests,
+ * initialization and shutdown state therefore cannot leak across servers.
  */
 
 import { spawn, ChildProcess } from 'child_process';
+import { createHash } from 'crypto';
 import * as path from 'path';
 import {
   TypeInfo,
@@ -30,6 +31,52 @@ interface PendingRequest {
   timeout: NodeJS.Timeout;
 }
 
+export type LSPServerState = 'starting' | 'ready' | 'stopping' | 'stopped' | 'failed';
+
+export interface LSPLifecycleEvent {
+  language: string;
+  projectHash: string;
+  pid?: number;
+  state: LSPServerState;
+  timestamp: number;
+  pendingRequestCount: number;
+  reason?: string;
+  initializeDurationMs?: number;
+  exitCode?: number | null;
+  exitSignal?: NodeJS.Signals | null;
+  forcedKill?: boolean;
+  retrySuppressed?: boolean;
+}
+
+interface ServerHandle {
+  key: string;
+  language: string;
+  projectPath: string;
+  process: ChildProcess;
+  state: LSPServerState;
+  initialization: Promise<boolean>;
+  stopping?: Promise<void>;
+  pendingRequests: Map<number, PendingRequest>;
+  buffer: Buffer;
+  startedAt: number;
+  terminationReason?: string;
+  forcedKill: boolean;
+  closed: boolean;
+  closePromise: Promise<void>;
+  resolveClose: () => void;
+  exitCode?: number | null;
+  exitSignal?: NodeJS.Signals | null;
+}
+
+export interface LSPLayerOptions {
+  /** Primarily useful to provide explicitly installed or test language servers. */
+  serverConfigs?: Record<string, LSPServerConfig>;
+  requestTimeoutMs?: number;
+  shutdownTimeoutMs?: number;
+  terminationGraceMs?: number;
+  onLifecycleEvent?: (event: LSPLifecycleEvent) => void;
+}
+
 const LSP_SERVER_CONFIGS: Record<string, LSPServerConfig> = {
   typescript: {
     command: 'typescript-language-server',
@@ -48,85 +95,136 @@ const LSP_SERVER_CONFIGS: Record<string, LSPServerConfig> = {
   },
 };
 
-const REQUEST_TIMEOUT_MS = 10000;
+const DEFAULT_REQUEST_TIMEOUT_MS = 10_000;
+const DEFAULT_SHUTDOWN_TIMEOUT_MS = 2_000;
+const DEFAULT_TERMINATION_GRACE_MS = 2_000;
 
 export class LSPLayer {
-  private servers: Map<string, ChildProcess> = new Map();
-  private messageId: number = 0;
-  private pendingRequests: Map<number, PendingRequest> = new Map();
-  private initialized: Map<string, boolean> = new Map();
-  private buffers: Map<string, string> = new Map();
+  private readonly handles = new Map<string, ServerHandle>();
+  private readonly failedCircuits = new Set<string>();
+  private readonly serverConfigs: Record<string, LSPServerConfig>;
+  private readonly requestTimeoutMs: number;
+  private readonly shutdownTimeoutMs: number;
+  private readonly terminationGraceMs: number;
+  private readonly onLifecycleEvent?: (event: LSPLifecycleEvent) => void;
+  private messageId = 0;
+  private shuttingDown?: Promise<void>;
+
+  constructor(options: LSPLayerOptions = {}) {
+    this.serverConfigs = options.serverConfigs || LSP_SERVER_CONFIGS;
+    this.requestTimeoutMs = options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
+    this.shutdownTimeoutMs = options.shutdownTimeoutMs ?? DEFAULT_SHUTDOWN_TIMEOUT_MS;
+    this.terminationGraceMs = options.terminationGraceMs ?? DEFAULT_TERMINATION_GRACE_MS;
+    this.onLifecycleEvent = options.onLifecycleEvent;
+  }
 
   private detectLanguage(filePath: string): SupportedLanguage | null {
     const ext = path.extname(filePath);
     return LANGUAGE_EXTENSIONS[ext] || null;
   }
 
-  private getServerConfig(language: string): LSPServerConfig | null {
-    return LSP_SERVER_CONFIGS[language] || null;
+  private serverKey(language: string, projectPath: string): string {
+    return `${language}:${path.resolve(projectPath)}`;
   }
 
   async ensureServer(language: string, projectPath: string): Promise<boolean> {
-    if (this.initialized.get(language)) {
-      return true;
-    }
-
-    const config = this.getServerConfig(language);
-    if (!config) {
+    const key = this.serverKey(language, projectPath);
+    if (this.failedCircuits.has(key)) {
+      this.emitLifecycle(language, projectPath, 'failed', 0, { retrySuppressed: true });
       return false;
     }
+    if (this.shuttingDown) return false;
 
+    const existing = this.handles.get(key);
+    if (existing?.state === 'ready') return true;
+    if (existing?.state === 'starting') return existing.initialization;
+    if (existing) return false;
+
+    const config = this.serverConfigs[language];
+    if (!config) return false;
+
+    let resolveClose!: () => void;
+    const closePromise = new Promise<void>((resolve) => {
+      resolveClose = resolve;
+    });
+    const child = spawn(config.command, config.args, {
+      cwd: projectPath,
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: { ...process.env },
+    });
+
+    const handle: ServerHandle = {
+      key,
+      language,
+      projectPath: path.resolve(projectPath),
+      process: child,
+      state: 'starting',
+      initialization: Promise.resolve(false),
+      pendingRequests: new Map(),
+      buffer: Buffer.alloc(0),
+      startedAt: Date.now(),
+      forcedKill: false,
+      closed: false,
+      closePromise,
+      resolveClose,
+    };
+
+    // Publish the owner before any asynchronous event can act on the process.
+    this.handles.set(key, handle);
+    this.emitHandleLifecycle(handle, 'starting');
+    this.attachProcessListeners(handle);
+    handle.initialization = this.initializeHandle(handle);
+    return handle.initialization;
+  }
+
+  private attachProcessListeners(handle: ServerHandle): void {
+    handle.process.stdout?.on('data', (data: Buffer) => this.handleServerData(handle, data));
+    // Drain stderr without retaining diagnostics in memory.
+    handle.process.stderr?.on('data', () => undefined);
+    handle.process.stdin?.on('error', () => undefined);
+    handle.process.once('error', (error) => {
+      if (handle.state !== 'stopping' && handle.state !== 'stopped') {
+        const reason = `process error: ${error.message}`;
+        handle.terminationReason = reason;
+        handle.state = 'failed';
+        this.failedCircuits.add(handle.key);
+        this.emitHandleLifecycle(handle, 'failed', { reason });
+        this.rejectPending(handle, new Error(`LSP server ${handle.language} failed`));
+        if (!handle.process.pid) this.markClosed(handle);
+        void this.terminateHandle(handle, reason);
+      }
+    });
+    handle.process.once('close', (code, signal) => {
+      handle.exitCode = code;
+      handle.exitSignal = signal;
+      this.markClosed(handle);
+      if (handle.state !== 'stopping' && handle.state !== 'stopped') {
+        handle.state = 'failed';
+        handle.terminationReason ||= 'process closed unexpectedly';
+        this.failedCircuits.add(handle.key);
+        this.emitHandleLifecycle(handle, 'failed', {
+          reason: handle.terminationReason,
+          exitCode: code,
+          exitSignal: signal,
+        });
+        this.rejectPending(handle, new Error(`LSP server ${handle.language} disconnected`));
+        this.releaseHandle(handle);
+      }
+    });
+  }
+
+  private markClosed(handle: ServerHandle): void {
+    if (handle.closed) return;
+    handle.closed = true;
+    handle.resolveClose();
+  }
+
+  private async initializeHandle(handle: ServerHandle): Promise<boolean> {
     try {
-      // Wrap spawn in a promise to properly handle ENOENT and other spawn errors
-      const serverProcess = await new Promise<ChildProcess>((resolve, reject) => {
-        const proc = spawn(config.command, config.args, {
-          cwd: projectPath,
-          stdio: ['pipe', 'pipe', 'pipe'],
-          env: { ...process.env },
-        });
-
-        // Handle spawn errors (e.g., command not found)
-        proc.on('error', (error) => {
-          reject(error);
-        });
-
-        // Give spawn a moment to fail or succeed
-        // If no error within a short time, assume spawn succeeded
-        setTimeout(() => {
-          if (proc.pid) {
-            resolve(proc);
-          } else {
-            reject(new Error(`Failed to spawn ${config.command}`));
-          }
-        }, 100);
-      });
-
-      this.servers.set(language, serverProcess);
-      this.buffers.set(language, '');
-
-      // Setup message handling
-      serverProcess.stdout?.on('data', (data: Buffer) => {
-        this.handleServerData(language, data);
-      });
-
-      serverProcess.stderr?.on('data', () => {
-        // Silently ignore stderr - LSP servers may output diagnostics
-      });
-
-      // Re-attach error handler for runtime errors (after spawn)
-      serverProcess.on('error', () => {
-        // Silently cleanup on error
-        this.cleanup(language);
-      });
-
-      serverProcess.on('exit', () => {
-        this.cleanup(language);
-      });
-
-      // Initialize the server
-      await this.sendRequest(language, 'initialize', {
+      await this.waitForSpawn(handle);
+      await this.sendRequest(handle, 'initialize', {
         processId: process.pid,
-        rootUri: `file://${projectPath}`,
+        rootUri: `file://${handle.projectPath}`,
         capabilities: {
           textDocument: {
             hover: { contentFormat: ['markdown', 'plaintext'] },
@@ -137,113 +235,253 @@ export class LSPLayer {
         },
       });
 
-      this.sendNotification(language, 'initialized', {});
-      this.initialized.set(language, true);
-
+      if (handle.state !== 'starting') throw new Error('LSP server stopped during initialize');
+      this.sendNotification(handle, 'initialized', {});
+      handle.state = 'ready';
+      this.emitHandleLifecycle(handle, 'ready', {
+        initializeDurationMs: Date.now() - handle.startedAt,
+      });
       return true;
-    } catch {
-      // LSP server not available - this is expected if the language server isn't installed
-      // Silently return false and fall back to non-LSP analysis
+    } catch (error) {
+      this.failedCircuits.add(handle.key);
+      const reason =
+        error instanceof Error ? `initialize failed: ${error.message}` : 'initialize failed';
+      handle.state = 'failed';
+      this.emitHandleLifecycle(handle, 'failed', {
+        reason,
+        initializeDurationMs: Date.now() - handle.startedAt,
+      });
+      await this.terminateHandle(
+        handle,
+        reason
+      );
       return false;
     }
   }
 
-  private handleServerData(language: string, data: Buffer): void {
-    let buffer = (this.buffers.get(language) || '') + data.toString();
-
-    while (true) {
-      const headerMatch = buffer.match(/Content-Length: (\d+)\r\n\r\n/);
-      if (!headerMatch) break;
-
-      const contentLength = parseInt(headerMatch[1], 10);
-      const headerEnd = headerMatch.index! + headerMatch[0].length;
-
-      if (buffer.length < headerEnd + contentLength) break;
-
-      const content = buffer.slice(headerEnd, headerEnd + contentLength);
-      buffer = buffer.slice(headerEnd + contentLength);
-
-      try {
-        const message: LSPMessage = JSON.parse(content);
-        this.handleMessage(message);
-      } catch {
-        // Silently ignore malformed messages
-      }
-    }
-
-    this.buffers.set(language, buffer);
-  }
-
-  private handleMessage(message: LSPMessage): void {
-    if (message.id !== undefined && this.pendingRequests.has(message.id)) {
-      const pending = this.pendingRequests.get(message.id)!;
-      this.pendingRequests.delete(message.id);
-      clearTimeout(pending.timeout);
-
-      if (message.error) {
-        pending.reject(new Error(message.error.message));
-      } else {
-        pending.resolve(message.result);
-      }
-    }
-  }
-
-  private sendRequest(language: string, method: string, params: unknown): Promise<unknown> {
+  private waitForSpawn(handle: ServerHandle): Promise<void> {
     return new Promise((resolve, reject) => {
-      const id = ++this.messageId;
-
-      const timeout = setTimeout(() => {
-        this.pendingRequests.delete(id);
-        reject(new Error(`LSP request timeout: ${method}`));
-      }, REQUEST_TIMEOUT_MS);
-
-      this.pendingRequests.set(id, { resolve, reject, timeout });
-
-      const message: LSPMessage = {
-        jsonrpc: '2.0',
-        id,
-        method,
-        params,
+      const onSpawn = (): void => {
+        cleanup();
+        resolve();
       };
-
-      this.sendMessage(language, message);
+      const onError = (error: Error): void => {
+        cleanup();
+        reject(error);
+      };
+      const onClose = (): void => {
+        cleanup();
+        reject(new Error('LSP server closed before spawn confirmation'));
+      };
+      const cleanup = (): void => {
+        handle.process.off('spawn', onSpawn);
+        handle.process.off('error', onError);
+        handle.process.off('close', onClose);
+      };
+      handle.process.once('spawn', onSpawn);
+      handle.process.once('error', onError);
+      handle.process.once('close', onClose);
     });
   }
 
-  private sendNotification(language: string, method: string, params: unknown): void {
-    const message: LSPMessage = {
-      jsonrpc: '2.0',
-      method,
-      params,
-    };
-    this.sendMessage(language, message);
+  private handleServerData(handle: ServerHandle, data: Buffer): void {
+    handle.buffer = Buffer.concat([handle.buffer, data]);
+
+    while (true) {
+      const headerEnd = handle.buffer.indexOf('\r\n\r\n');
+      if (headerEnd < 0) return;
+      const header = handle.buffer.subarray(0, headerEnd).toString('ascii');
+      const match = /(?:^|\r\n)Content-Length:\s*(\d+)/i.exec(header);
+      if (!match) {
+        handle.buffer = Buffer.alloc(0);
+        return;
+      }
+      const contentLength = Number(match[1]);
+      const bodyStart = headerEnd + 4;
+      if (handle.buffer.length < bodyStart + contentLength) return;
+
+      const body = handle.buffer.subarray(bodyStart, bodyStart + contentLength);
+      handle.buffer = handle.buffer.subarray(bodyStart + contentLength);
+      try {
+        this.handleMessage(handle, JSON.parse(body.toString('utf8')) as LSPMessage);
+      } catch {
+        // Malformed server messages are ignored without affecting another handle.
+      }
+    }
   }
 
-  private sendMessage(language: string, message: LSPMessage): void {
-    const server = this.servers.get(language);
-    if (!server?.stdin?.writable) return;
+  private handleMessage(handle: ServerHandle, message: LSPMessage): void {
+    if (message.id === undefined) return;
+    const pending = handle.pendingRequests.get(message.id);
+    if (!pending) return;
 
+    handle.pendingRequests.delete(message.id);
+    clearTimeout(pending.timeout);
+    if (message.error) pending.reject(new Error(message.error.message));
+    else pending.resolve(message.result);
+  }
+
+  private sendRequest(
+    handle: ServerHandle,
+    method: string,
+    params: unknown,
+    timeoutMs = this.requestTimeoutMs
+  ): Promise<unknown> {
+    return new Promise((resolve, reject) => {
+      const id = ++this.messageId;
+      const timeout = setTimeout(() => {
+        handle.pendingRequests.delete(id);
+        reject(new Error(`LSP request timeout: ${method}`));
+      }, timeoutMs);
+      handle.pendingRequests.set(id, { resolve, reject, timeout });
+
+      if (!this.sendMessage(handle, { jsonrpc: '2.0', id, method, params })) {
+        clearTimeout(timeout);
+        handle.pendingRequests.delete(id);
+        reject(new Error(`LSP server ${handle.language} is not writable`));
+      }
+    });
+  }
+
+  private sendNotification(handle: ServerHandle, method: string, params: unknown): boolean {
+    return this.sendMessage(handle, { jsonrpc: '2.0', method, params });
+  }
+
+  private sendMessage(handle: ServerHandle, message: LSPMessage): boolean {
+    const stdin = handle.process.stdin;
+    if (!stdin?.writable || stdin.destroyed) return false;
     const content = JSON.stringify(message);
     const header = `Content-Length: ${Buffer.byteLength(content)}\r\n\r\n`;
-
     try {
-      server.stdin.write(header + content);
+      stdin.write(header + content);
+      return true;
     } catch {
-      // Silently ignore send failures
+      return false;
     }
   }
 
-  private cleanup(language: string): void {
-    this.servers.delete(language);
-    this.initialized.delete(language);
-    this.buffers.delete(language);
-
-    // Reject all pending requests for this language
-    for (const [id, pending] of this.pendingRequests) {
+  private rejectPending(handle: ServerHandle, error: Error): void {
+    for (const pending of handle.pendingRequests.values()) {
       clearTimeout(pending.timeout);
-      pending.reject(new Error(`LSP server ${language} disconnected`));
-      this.pendingRequests.delete(id);
+      pending.reject(error);
     }
+    handle.pendingRequests.clear();
+  }
+
+  private async terminateHandle(
+    handle: ServerHandle,
+    reason: string,
+    waitForNaturalExit = false
+  ): Promise<void> {
+    if (handle.stopping) return handle.stopping;
+    if (handle.state === 'stopped' && handle.closed) return;
+
+    handle.terminationReason = reason;
+    handle.state = 'stopping';
+    this.emitHandleLifecycle(handle, 'stopping', { reason });
+    handle.stopping = (async () => {
+      this.rejectPending(handle, new Error(`LSP server ${handle.language} terminated: ${reason}`));
+      handle.process.stdin?.end();
+
+      if (!handle.closed) {
+        const exitedNaturally =
+          waitForNaturalExit && (await this.waitForClose(handle, this.terminationGraceMs));
+        if (!exitedNaturally) {
+          this.signal(handle, 'SIGTERM');
+          if (!(await this.waitForClose(handle, this.terminationGraceMs))) {
+            handle.forcedKill = true;
+            this.signal(handle, 'SIGKILL');
+            await handle.closePromise;
+          }
+        }
+      }
+
+      handle.state = 'stopped';
+      this.emitHandleLifecycle(handle, 'stopped', {
+        reason,
+        exitCode: handle.exitCode,
+        exitSignal: handle.exitSignal,
+        forcedKill: handle.forcedKill,
+      });
+      this.releaseHandle(handle);
+    })();
+    return handle.stopping;
+  }
+
+  private signal(handle: ServerHandle, signal: NodeJS.Signals): void {
+    if (handle.closed || !handle.process.pid) return;
+    try {
+      handle.process.kill(signal);
+    } catch {
+      // A concurrent process exit is equivalent to successful termination.
+    }
+  }
+
+  private waitForClose(handle: ServerHandle, timeoutMs: number): Promise<boolean> {
+    if (handle.closed) return Promise.resolve(true);
+    return new Promise((resolve) => {
+      const timeout = setTimeout(() => resolve(false), timeoutMs);
+      handle.closePromise.then(() => {
+        clearTimeout(timeout);
+        resolve(true);
+      });
+    });
+  }
+
+  private releaseHandle(handle: ServerHandle): void {
+    if (this.handles.get(handle.key) === handle) this.handles.delete(handle.key);
+    this.rejectPending(handle, new Error(`LSP server ${handle.language} released`));
+    handle.buffer = Buffer.alloc(0);
+    handle.process.stdin?.removeAllListeners();
+    handle.process.stdout?.removeAllListeners();
+    handle.process.stderr?.removeAllListeners();
+    handle.process.removeAllListeners();
+  }
+
+  private emitHandleLifecycle(
+    handle: ServerHandle,
+    state: LSPServerState,
+    details: Partial<LSPLifecycleEvent> = {}
+  ): void {
+    this.emitLifecycle(
+      handle.language,
+      handle.projectPath,
+      state,
+      handle.pendingRequests.size,
+      { pid: handle.process.pid, ...details }
+    );
+  }
+
+  private emitLifecycle(
+    language: string,
+    projectPath: string,
+    state: LSPServerState,
+    pendingRequestCount: number,
+    details: Partial<LSPLifecycleEvent> = {}
+  ): void {
+    if (!this.onLifecycleEvent) return;
+    const event: LSPLifecycleEvent = {
+      language,
+      projectHash: createHash('sha256').update(path.resolve(projectPath)).digest('hex').slice(0, 12),
+      state,
+      timestamp: Date.now(),
+      pendingRequestCount,
+      ...details,
+    };
+    try {
+      this.onLifecycleEvent(event);
+    } catch {
+      // Observability must never change process ownership or fallback behavior.
+    }
+  }
+
+  private async readyHandle(
+    language: string,
+    projectPath: string
+  ): Promise<ServerHandle | undefined> {
+    if (!(await this.ensureServer(language, projectPath))) return undefined;
+    const handle = this.handles.get(this.serverKey(language, projectPath));
+    return handle?.state === 'ready' ? handle : undefined;
   }
 
   async getTypeInfo(
@@ -254,23 +492,20 @@ export class LSPLayer {
   ): Promise<TypeInfo | null> {
     const language = this.detectLanguage(filePath);
     if (!language) return null;
-
-    const serverReady = await this.ensureServer(language, projectPath);
-    if (!serverReady) return null;
+    const handle = await this.readyHandle(language, projectPath);
+    if (!handle) return null;
 
     try {
-      const result = await this.sendRequest(language, 'textDocument/hover', {
+      const result = await this.sendRequest(handle, 'textDocument/hover', {
         textDocument: { uri: `file://${filePath}` },
         position: { line: line - 1, character: column },
       });
-
       if (result && typeof result === 'object' && 'contents' in result) {
         return this.parseHoverResult((result as { contents: unknown }).contents);
       }
     } catch {
-      // LSP request failed - return null to fall back to non-LSP analysis
+      // Fall back to the non-LSP analysis.
     }
-
     return null;
   }
 
@@ -282,17 +517,15 @@ export class LSPLayer {
   ): Promise<ReferenceLocation[]> {
     const language = this.detectLanguage(filePath);
     if (!language) return [];
-
-    const serverReady = await this.ensureServer(language, projectPath);
-    if (!serverReady) return [];
+    const handle = await this.readyHandle(language, projectPath);
+    if (!handle) return [];
 
     try {
-      const result = await this.sendRequest(language, 'textDocument/references', {
+      const result = await this.sendRequest(handle, 'textDocument/references', {
         textDocument: { uri: `file://${filePath}` },
         position: { line: line - 1, character: column },
         context: { includeDeclaration: true },
       });
-
       if (Array.isArray(result)) {
         return result.map((ref: { uri: string; range: { start: { line: number; character: number } } }) => ({
           file: ref.uri.replace('file://', ''),
@@ -301,9 +534,8 @@ export class LSPLayer {
         }));
       }
     } catch {
-      // LSP request failed - return empty array
+      // Fall back to an empty result.
     }
-
     return [];
   }
 
@@ -315,16 +547,14 @@ export class LSPLayer {
   ): Promise<ReferenceLocation | null> {
     const language = this.detectLanguage(filePath);
     if (!language) return null;
-
-    const serverReady = await this.ensureServer(language, projectPath);
-    if (!serverReady) return null;
+    const handle = await this.readyHandle(language, projectPath);
+    if (!handle) return null;
 
     try {
-      const result = await this.sendRequest(language, 'textDocument/definition', {
+      const result = await this.sendRequest(handle, 'textDocument/definition', {
         textDocument: { uri: `file://${filePath}` },
         position: { line: line - 1, character: column },
       });
-
       if (Array.isArray(result) && result.length > 0) {
         const def = result[0] as { uri: string; range: { start: { line: number; character: number } } };
         return {
@@ -334,9 +564,8 @@ export class LSPLayer {
         };
       }
     } catch {
-      // LSP request failed - return null
+      // Fall back to the non-LSP analysis.
     }
-
     return null;
   }
 
@@ -348,16 +577,14 @@ export class LSPLayer {
   ): Promise<ReferenceLocation[]> {
     const language = this.detectLanguage(filePath);
     if (!language) return [];
-
-    const serverReady = await this.ensureServer(language, projectPath);
-    if (!serverReady) return [];
+    const handle = await this.readyHandle(language, projectPath);
+    if (!handle) return [];
 
     try {
-      const result = await this.sendRequest(language, 'textDocument/implementation', {
+      const result = await this.sendRequest(handle, 'textDocument/implementation', {
         textDocument: { uri: `file://${filePath}` },
         position: { line: line - 1, character: column },
       });
-
       if (Array.isArray(result)) {
         return result.map((impl: { uri: string; range: { start: { line: number; character: number } } }) => ({
           file: impl.uri.replace('file://', ''),
@@ -366,18 +593,15 @@ export class LSPLayer {
         }));
       }
     } catch {
-      // LSP request failed - return empty array
+      // Fall back to an empty result.
     }
-
     return [];
   }
 
   private parseHoverResult(contents: unknown): TypeInfo {
     let text = '';
-
-    if (typeof contents === 'string') {
-      text = contents;
-    } else if (Array.isArray(contents)) {
+    if (typeof contents === 'string') text = contents;
+    else if (Array.isArray(contents)) {
       text = contents
         .map((c) => (typeof c === 'string' ? c : (c as { value?: string }).value || ''))
         .join('\n');
@@ -385,10 +609,8 @@ export class LSPLayer {
       text = (contents as { value?: string }).value || '';
     }
 
-    // Extract type from markdown code blocks
     const codeMatch = text.match(/```\w*\n?([\s\S]*?)\n?```/);
     const typeText = codeMatch ? codeMatch[1] : text;
-
     return {
       name: typeText.split('\n')[0] || 'unknown',
       fullType: typeText,
@@ -397,30 +619,34 @@ export class LSPLayer {
   }
 
   async shutdown(): Promise<void> {
-    const shutdownPromises: Promise<void>[] = [];
+    if (this.shuttingDown) return this.shuttingDown;
+    this.shuttingDown = (async () => {
+      const handles = [...this.handles.values()];
+      await Promise.all(handles.map((handle) => this.shutdownHandle(handle)));
+    })();
+    return this.shuttingDown;
+  }
 
-    for (const [language] of this.servers) {
-      shutdownPromises.push(
-        (async () => {
-          try {
-            await this.sendRequest(language, 'shutdown', null);
-            this.sendNotification(language, 'exit', null);
-          } catch {
-            // Ignore shutdown errors
-          }
-          this.cleanup(language);
-        })()
-      );
+  private async shutdownHandle(handle: ServerHandle): Promise<void> {
+    if (handle.stopping) return handle.stopping;
+    if (handle.state === 'ready') {
+      try {
+        await this.sendRequest(handle, 'shutdown', null, this.shutdownTimeoutMs);
+        this.sendNotification(handle, 'exit', null);
+      } catch {
+        // Process termination below is authoritative even if the protocol fails.
+      }
     }
-
-    await Promise.all(shutdownPromises);
+    await this.terminateHandle(handle, 'layer shutdown', true);
   }
 
   isServerAvailable(language: string): boolean {
-    return this.initialized.get(language) === true;
+    return [...this.handles.values()].some(
+      (handle) => handle.language === language && handle.state === 'ready'
+    );
   }
 
   getAvailableLanguages(): string[] {
-    return Object.keys(LSP_SERVER_CONFIGS);
+    return Object.keys(this.serverConfigs);
   }
 }

--- a/src/harness/adapters/out/semantic/lsp/lspLayer.ts
+++ b/src/harness/adapters/out/semantic/lsp/lspLayer.ts
@@ -57,6 +57,7 @@ interface ServerHandle {
   initialization: Promise<boolean>;
   stopping?: Promise<void>;
   pendingRequests: Map<number, PendingRequest>;
+  timers: Set<NodeJS.Timeout>;
   buffer: Buffer;
   startedAt: number;
   terminationReason?: string;
@@ -74,6 +75,9 @@ export interface LSPLayerOptions {
   requestTimeoutMs?: number;
   shutdownTimeoutMs?: number;
   terminationGraceMs?: number;
+  maxHeaderBytes?: number;
+  maxBodyBytes?: number;
+  maxReceiveBufferBytes?: number;
   onLifecycleEvent?: (event: LSPLifecycleEvent) => void;
 }
 
@@ -98,6 +102,15 @@ const LSP_SERVER_CONFIGS: Record<string, LSPServerConfig> = {
 const DEFAULT_REQUEST_TIMEOUT_MS = 10_000;
 const DEFAULT_SHUTDOWN_TIMEOUT_MS = 2_000;
 const DEFAULT_TERMINATION_GRACE_MS = 2_000;
+export const MAX_LSP_HEADER_BYTES = 16 * 1024;
+export const MAX_LSP_BODY_BYTES = 8 * 1024 * 1024;
+export const MAX_LSP_RECEIVE_BUFFER_BYTES =
+  MAX_LSP_HEADER_BYTES + 4 + MAX_LSP_BODY_BYTES;
+
+function boundedProtocolLimit(value: number | undefined, maximum: number): number {
+  if (value === undefined || !Number.isSafeInteger(value) || value <= 0) return maximum;
+  return Math.min(value, maximum);
+}
 
 export class LSPLayer {
   private readonly handles = new Map<string, ServerHandle>();
@@ -106,6 +119,9 @@ export class LSPLayer {
   private readonly requestTimeoutMs: number;
   private readonly shutdownTimeoutMs: number;
   private readonly terminationGraceMs: number;
+  private readonly maxHeaderBytes: number;
+  private readonly maxBodyBytes: number;
+  private readonly maxReceiveBufferBytes: number;
   private readonly onLifecycleEvent?: (event: LSPLifecycleEvent) => void;
   private messageId = 0;
   private shuttingDown?: Promise<void>;
@@ -115,6 +131,12 @@ export class LSPLayer {
     this.requestTimeoutMs = options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
     this.shutdownTimeoutMs = options.shutdownTimeoutMs ?? DEFAULT_SHUTDOWN_TIMEOUT_MS;
     this.terminationGraceMs = options.terminationGraceMs ?? DEFAULT_TERMINATION_GRACE_MS;
+    this.maxHeaderBytes = boundedProtocolLimit(options.maxHeaderBytes, MAX_LSP_HEADER_BYTES);
+    this.maxBodyBytes = boundedProtocolLimit(options.maxBodyBytes, MAX_LSP_BODY_BYTES);
+    this.maxReceiveBufferBytes = boundedProtocolLimit(
+      options.maxReceiveBufferBytes,
+      MAX_LSP_RECEIVE_BUFFER_BYTES
+    );
     this.onLifecycleEvent = options.onLifecycleEvent;
   }
 
@@ -161,6 +183,7 @@ export class LSPLayer {
       state: 'starting',
       initialization: Promise.resolve(false),
       pendingRequests: new Map(),
+      timers: new Set(),
       buffer: Buffer.alloc(0),
       startedAt: Date.now(),
       forcedKill: false,
@@ -243,6 +266,10 @@ export class LSPLayer {
       });
       return true;
     } catch (error) {
+      if (handle.state === 'stopping' || handle.state === 'stopped') {
+        await handle.stopping;
+        return false;
+      }
       this.failedCircuits.add(handle.key);
       const reason =
         error instanceof Error ? `initialize failed: ${error.message}` : 'initialize failed';
@@ -285,23 +312,61 @@ export class LSPLayer {
   }
 
   private handleServerData(handle: ServerHandle, data: Buffer): void {
+    if (handle.state === 'stopping' || handle.state === 'stopped') return;
+    if (data.length > this.maxReceiveBufferBytes - handle.buffer.length) {
+      this.failProtocol(handle, 'receive buffer limit exceeded');
+      return;
+    }
     handle.buffer = Buffer.concat([handle.buffer, data]);
 
     while (true) {
       const headerEnd = handle.buffer.indexOf('\r\n\r\n');
-      if (headerEnd < 0) return;
-      const header = handle.buffer.subarray(0, headerEnd).toString('ascii');
-      const match = /(?:^|\r\n)Content-Length:\s*(\d+)/i.exec(header);
-      if (!match) {
-        handle.buffer = Buffer.alloc(0);
+      if (headerEnd < 0) {
+        if (handle.buffer.length > this.maxHeaderBytes) {
+          this.failProtocol(handle, 'incomplete header limit exceeded');
+        }
         return;
       }
-      const contentLength = Number(match[1]);
+      if (headerEnd > this.maxHeaderBytes) {
+        this.failProtocol(handle, 'header limit exceeded');
+        return;
+      }
+      const header = handle.buffer.subarray(0, headerEnd).toString('ascii');
+      const contentLengthHeaders = header
+        .split('\r\n')
+        .filter((line) => /^Content-Length:/i.test(line));
+      if (contentLengthHeaders.length !== 1) {
+        this.failProtocol(handle, 'expected exactly one Content-Length header');
+        return;
+      }
+      const rawContentLength = contentLengthHeaders[0].slice(
+        contentLengthHeaders[0].indexOf(':') + 1
+      ).trim();
+      if (!/^[0-9]+$/.test(rawContentLength)) {
+        this.failProtocol(handle, 'invalid Content-Length');
+        return;
+      }
+      const contentLength = Number(rawContentLength);
+      if (
+        !Number.isSafeInteger(contentLength) ||
+        contentLength <= 0 ||
+        contentLength > this.maxBodyBytes
+      ) {
+        this.failProtocol(handle, 'Content-Length exceeds body limit');
+        return;
+      }
       const bodyStart = headerEnd + 4;
+      if (bodyStart + contentLength > this.maxReceiveBufferBytes) {
+        this.failProtocol(handle, 'frame exceeds receive buffer limit');
+        return;
+      }
       if (handle.buffer.length < bodyStart + contentLength) return;
 
       const body = handle.buffer.subarray(bodyStart, bodyStart + contentLength);
-      handle.buffer = handle.buffer.subarray(bodyStart + contentLength);
+      const remainingStart = bodyStart + contentLength;
+      handle.buffer = remainingStart === handle.buffer.length
+        ? Buffer.alloc(0)
+        : Buffer.from(handle.buffer.subarray(remainingStart));
       try {
         this.handleMessage(handle, JSON.parse(body.toString('utf8')) as LSPMessage);
       } catch {
@@ -310,13 +375,30 @@ export class LSPLayer {
     }
   }
 
+  private failProtocol(handle: ServerHandle, detail: string): void {
+    if (
+      handle.state === 'failed' ||
+      handle.state === 'stopping' ||
+      handle.state === 'stopped'
+    ) return;
+
+    const reason = `protocol overflow: ${detail}`;
+    handle.buffer = Buffer.alloc(0);
+    handle.terminationReason = reason;
+    handle.state = 'failed';
+    this.failedCircuits.add(handle.key);
+    this.emitHandleLifecycle(handle, 'failed', { reason });
+    this.rejectPending(handle, new Error(`LSP server ${handle.language} ${reason}`));
+    void this.terminateHandle(handle, reason);
+  }
+
   private handleMessage(handle: ServerHandle, message: LSPMessage): void {
     if (message.id === undefined) return;
     const pending = handle.pendingRequests.get(message.id);
     if (!pending) return;
 
     handle.pendingRequests.delete(message.id);
-    clearTimeout(pending.timeout);
+    this.clearHandleTimeout(handle, pending.timeout);
     if (message.error) pending.reject(new Error(message.error.message));
     else pending.resolve(message.result);
   }
@@ -329,14 +411,14 @@ export class LSPLayer {
   ): Promise<unknown> {
     return new Promise((resolve, reject) => {
       const id = ++this.messageId;
-      const timeout = setTimeout(() => {
+      const timeout = this.setHandleTimeout(handle, () => {
         handle.pendingRequests.delete(id);
         reject(new Error(`LSP request timeout: ${method}`));
       }, timeoutMs);
       handle.pendingRequests.set(id, { resolve, reject, timeout });
 
       if (!this.sendMessage(handle, { jsonrpc: '2.0', id, method, params })) {
-        clearTimeout(timeout);
+        this.clearHandleTimeout(handle, timeout);
         handle.pendingRequests.delete(id);
         reject(new Error(`LSP server ${handle.language} is not writable`));
       }
@@ -362,7 +444,7 @@ export class LSPLayer {
 
   private rejectPending(handle: ServerHandle, error: Error): void {
     for (const pending of handle.pendingRequests.values()) {
-      clearTimeout(pending.timeout);
+      this.clearHandleTimeout(handle, pending.timeout);
       pending.reject(error);
     }
     handle.pendingRequests.clear();
@@ -420,17 +502,37 @@ export class LSPLayer {
   private waitForClose(handle: ServerHandle, timeoutMs: number): Promise<boolean> {
     if (handle.closed) return Promise.resolve(true);
     return new Promise((resolve) => {
-      const timeout = setTimeout(() => resolve(false), timeoutMs);
+      const timeout = this.setHandleTimeout(handle, () => resolve(false), timeoutMs);
       handle.closePromise.then(() => {
-        clearTimeout(timeout);
+        this.clearHandleTimeout(handle, timeout);
         resolve(true);
       });
     });
   }
 
+  private setHandleTimeout(
+    handle: ServerHandle,
+    callback: () => void,
+    timeoutMs: number
+  ): NodeJS.Timeout {
+    const timeout = setTimeout(() => {
+      handle.timers.delete(timeout);
+      callback();
+    }, timeoutMs);
+    handle.timers.add(timeout);
+    return timeout;
+  }
+
+  private clearHandleTimeout(handle: ServerHandle, timeout: NodeJS.Timeout): void {
+    clearTimeout(timeout);
+    handle.timers.delete(timeout);
+  }
+
   private releaseHandle(handle: ServerHandle): void {
     if (this.handles.get(handle.key) === handle) this.handles.delete(handle.key);
     this.rejectPending(handle, new Error(`LSP server ${handle.language} released`));
+    for (const timer of handle.timers) clearTimeout(timer);
+    handle.timers.clear();
     handle.buffer = Buffer.alloc(0);
     handle.process.stdin?.removeAllListeners();
     handle.process.stdout?.removeAllListeners();


### PR DESCRIPTION
## What changed

- replace separate language-level process, buffer, initialization, and request maps with one owned server handle per language/project
- deduplicate concurrent initialization and open a per-analyzer circuit after initialization failure
- scope pending requests, receive state, and timers to their owning process
- enforce absolute per-server limits of 16 KiB for headers, 8 MiB for bodies, and a bounded combined receive frame
- parse receive data with a segmented header accumulator and one final body allocation, eliminating per-chunk whole-buffer copies
- validate that every frame has exactly one positive, safe, decimal `Content-Length` within the body ceiling
- fail pending requests, open the circuit, clear framing state, and terminate/reap the owned child on protocol overflow
- spawn POSIX servers in dedicated process groups and terminate the entire group; use bounded `taskkill /T` handling on Windows
- make initialization failure and shutdown terminate process trees with bounded graceful exit, SIGTERM, SIGKILL, and post-kill waits
- make shutdown idempotent and safe across starting, ready, failed, and stopping states
- add executable fake-server regressions for signal-ignoring descendants and a near-8 MiB response fragmented into 1 KiB writes, in addition to rejection, timeout, crash, overflow, concurrency, and cleanup coverage

## Why

The original lifecycle implementation could return from failed initialization or shutdown after deleting bookkeeping while leaving the language-server child alive. A later request could spawn another child and overwrite ownership. Killing only a launcher PID also allowed descendants with inherited stdio to survive and could make shutdown wait forever for `close` after `SIGKILL`.

The receive parser also concatenated all accumulated server output for every stdout chunk. A valid large response delivered in small fragments therefore caused quadratic copying and allocation, while malformed frames needed hard memory ceilings.

## Impact

Optional LSP semantic analysis keeps its existing fallback values, but every spawned server now has one tracked owner and bounded protocol state. POSIX launchers and descendants share a dedicated process group; Windows termination uses the native process-tree command. All termination stages, including the post-`SIGKILL` observation window, are bounded. Failed initialization or protocol overflow is suppressed for the same language/project for the lifetime of the analyzer.

## Review findings addressed

- process-tree termination now covers signal-ignoring descendants, with POSIX process groups and Windows `/T` handling
- the post-`SIGKILL` wait is bounded and no longer depends indefinitely on ChildProcess `close`
- receive accumulation no longer runs `Buffer.concat` for every stdout chunk; completed bodies are copied into their final allocation once
- executable regressions cover an inherited-stdio descendant and a fragmented near-limit valid response while retaining overflow paths

## Validation

- `npm run build`
- `npm test -- --runInBand` — 93 suites, 578 tests passed
- focused executable lifecycle suite — 14 tests passed, including signal-ignoring process trees and a fragmented near-8 MiB response
- `git diff --check`
